### PR TITLE
ocl-cache-fix - Generating hash from Canonical URL + Version for OCL cache.

### DIFF
--- a/tests/ocl/ocl-cm.test.js
+++ b/tests/ocl/ocl-cm.test.js
@@ -158,7 +158,10 @@ describe('OCL ConceptMap integration', () => {
       url: 'http://example.org/cached-cm',
       version: '1.0.0'
     };
-    provider.conceptMapMap.set('http://example.org/cached-cm|1.0.0', cached);
+    // Gerar hash igual ao m├®todo de produ├º├úo
+    const crypto = require('crypto');
+    const cacheKey = crypto.createHash('sha256').update('http://example.org/cached-cm|1.0.0').digest('hex');
+    provider.conceptMapMap.set(cacheKey, cached);
     const out = await provider.fetchConceptMap('http://example.org/cached-cm', '1.0.0');
     expect(out).toBe(cached);
   });

--- a/tests/ocl/ocl-helpers.test.js
+++ b/tests/ocl/ocl-helpers.test.js
@@ -116,7 +116,6 @@ describe('OCL helper modules', () => {
 
     const out = getCacheFilePath(path.join(CACHE_BASE_DIR, 'tmp'), 'http://example.org/vs', '1.0.0', 'f1');
     expect(out.endsWith('.json')).toBe(true);
-    expect(out).toContain('_p_f1');
 
     const dir = path.join(process.cwd(), 'data', 'terminology-cache', 'ocl', 'helper-test');
     await ensureCacheDirectories(dir);

--- a/tests/ocl/ocl-vs-advanced.test.js
+++ b/tests/ocl/ocl-vs-advanced.test.js
@@ -190,7 +190,9 @@ describe('OCL ValueSet advanced provider behavior', () => {
     provider.valueSetMap.set(`${vs.url}|${vs.version}`, vs);
     provider.valueSetMap.set(vs.id, vs);
 
-    const cacheKey = `${vs.url}|${vs.version}|default`;
+    const crypto = require('crypto');
+    const base = `${vs.url}|${vs.version}|default`;
+    const cacheKey = crypto.createHash('sha256').update(base).digest('hex');
     provider.backgroundExpansionCache.set(cacheKey, {
       expansion: { contains: [{ system: 'x', code: '1' }] },
       metadataSignature: 'stale-signature',

--- a/tx/ocl/cache/cache-paths.cjs
+++ b/tx/ocl/cache/cache-paths.cjs
@@ -15,11 +15,10 @@ function sanitizeFilename(text) {
 }
 
 function getCacheFilePath(baseDir, canonicalUrl, version = null, paramsKey = null) {
-  const filename = sanitizeFilename(canonicalUrl)
-    + (version ? `_${sanitizeFilename(version)}` : '')
-    + (paramsKey && paramsKey !== 'default' ? `_p_${sanitizeFilename(paramsKey)}` : '')
-    + '.json';
-
+  const crypto = require('crypto');
+  const base = `${canonicalUrl}|${version || ''}|${paramsKey || 'default'}`;
+  const hash = crypto.createHash('sha256').update(base).digest('hex');
+  const filename = `${hash}.json`;
   return path.join(baseDir, filename);
 }
 

--- a/tx/ocl/cm-ocl.cjs
+++ b/tx/ocl/cm-ocl.cjs
@@ -46,7 +46,10 @@ class OCLConceptMapProvider extends AbstractConceptMapProvider {
   async fetchConceptMap(url, version) {
     this._validateFetchParams(url, version);
 
-    const direct = this.conceptMapMap.get(`${url}|${version}`) || this.conceptMapMap.get(url);
+    const crypto = require('crypto');
+    const base = `${url}|${version || ''}`;
+    const hash = crypto.createHash('sha256').update(base).digest('hex');
+    const direct = this.conceptMapMap.get(hash);
     if (direct) {
       return direct;
     }

--- a/tx/ocl/cs-ocl.cjs
+++ b/tx/ocl/cs-ocl.cjs
@@ -1733,8 +1733,11 @@ class OCLSourceCodeSystemFactory extends CodeSystemFactoryProvider {
   }
 
   #resourceKey() {
+    const crypto = require('crypto');
     const normalizedSystem = OCLSourceCodeSystemFactory.#normalizeSystem(this.system());
-    return `${normalizedSystem}|${this.version() || ''}`;
+    const base = `${normalizedSystem}|${this.version() || ''}`;
+    const hash = crypto.createHash('sha256').update(base).digest('hex');
+    return hash;
   }
 
   currentChecksum() {

--- a/tx/ocl/vs-ocl.cjs
+++ b/tx/ocl/vs-ocl.cjs
@@ -22,13 +22,28 @@ function normalizeCanonicalSystem(system) {
     return system;
   }
 
-  const trimmed = system.trim();
+  let trimmed = system.trim();
   if (!trimmed) {
     return trimmed;
   }
 
-  // Treat canonical URLs with and without trailing slash as equivalent.
-  return trimmed.replace(/\/+$/, '');
+  // Normaliza protocolo para evitar falsos positivos no cache
+  // http://, https://, urn:uuid: s├úo tratados como diferentes, mas remove duplicidade de barras
+  // Remove barras finais
+  trimmed = trimmed.replace(/\/+$/, '');
+
+  // Corrige casos de https: sem barras
+  if (/^https:[^/]/.test(trimmed)) {
+    trimmed = trimmed.replace(/^https:/, 'https://');
+  }
+  if (/^http:[^/]/.test(trimmed)) {
+    trimmed = trimmed.replace(/^http:/, 'http://');
+  }
+
+  // Remove m├║ltiplas barras ap├│s protocolo
+  trimmed = trimmed.replace(/^(https?:\/)+/, '$1//');
+
+  return trimmed;
 }
 
 class OCLValueSetProvider extends AbstractValueSetProvider {
@@ -868,7 +883,9 @@ class OCLValueSetProvider extends AbstractValueSetProvider {
     if (!base) {
       return null;
     }
-    return `${base}|${paramsKey || 'default'}`;
+    const crypto = require('crypto');
+    const hash = crypto.createHash('sha256').update(`${base}|${paramsKey || 'default'}`).digest('hex');
+    return hash;
   }
 
   #invalidateExpansionCache(vs) {


### PR DESCRIPTION
This pull request introduces a significant change to how cache keys are generated and normalized across the OCL modules. Instead of using plain concatenated strings, cache keys are now consistently generated using SHA-256 hashes of normalized input values. This ensures greater consistency, avoids key collisions, and handles edge cases in URL formatting. Additionally, URL normalization is improved to handle protocol and trailing slash variations more robustly.

Key changes include:

### Cache Key Generation and Usage

* Replaced all plain string cache keys with SHA-256 hashed keys in `OCLConceptMapProvider`, `OCLValueSetProvider`, `OCLSourceCodeSystemFactory`, and related test files to ensure consistent and collision-resistant cache key generation. (`tx/ocl/cm-ocl.cjs` [[1]](diffhunk://#diff-b8b1f3984fe822c72b68e0641bc2655ec334b52432df48996bcb1b7db87ed88cL49-R52) `tx/ocl/vs-ocl.cjs` [[2]](diffhunk://#diff-5a9fe20e7ad166338aed724cce44e95a5ea29210f2c7b867fe21dc12a6a533feL871-R888) `tx/ocl/cs-ocl.cjs` [[3]](diffhunk://#diff-b75d4fdf17c602fddab3b92c3972a53ec81ca02df877f93f3e2eedeb9b2bf7f2R1736-R1740) `tx/ocl/cache/cache-paths.cjs` [[4]](diffhunk://#diff-d7dc36326a16b98d39137f2bce65524152710551feec56fd2d07ed4be5e6d370L18-R21) `tests/ocl/ocl-cm.test.js` [[5]](diffhunk://#diff-90214242e298e1102dd3af72a2b7ae62f0d8e12cd254d134c212a3821975d4ffL161-R164) `tests/ocl/ocl-vs-advanced.test.js` [[6]](diffhunk://#diff-6dbedf81cea5ac8dceba2ebe26e4ab6ea339b08d75a74a0e91d26cce63b59762L193-R195)

### URL Normalization Improvements

* Enhanced the `normalizeCanonicalSystem` function to standardize protocol formatting, remove duplicate slashes, and trim trailing slashes, reducing false cache misses due to minor URL differences. (`tx/ocl/vs-ocl.cjs` [tx/ocl/vs-ocl.cjsL25-R46](diffhunk://#diff-5a9fe20e7ad166338aed724cce44e95a5ea29210f2c7b867fe21dc12a6a533feL25-R46))

### Test Adjustments

* Updated tests to align with the new hashed cache key scheme, removing or adapting assertions that previously depended on the old cache key format. (`tests/ocl/ocl-helpers.test.js` [[1]](diffhunk://#diff-003f7bf99af52eb413cc6e181427452ae557ef5ccdd9a9b73a7ac594b057a974L119) `tests/ocl/ocl-cm.test.js` [[2]](diffhunk://#diff-90214242e298e1102dd3af72a2b7ae62f0d8e12cd254d134c212a3821975d4ffL161-R164) `tests/ocl/ocl-vs-advanced.test.js` [[3]](diffhunk://#diff-6dbedf81cea5ac8dceba2ebe26e4ab6ea339b08d75a74a0e91d26cce63b59762L193-R195)…nvironment.