### PR TITLE
fix(snomed): align getLanguageCode with mapLanguageCode byte mapping

### DIFF
--- a/tx/cs/cs-snomed.js
+++ b/tx/cs/cs-snomed.js
@@ -615,10 +615,14 @@ class SnomedProvider extends BaseCSServices {
   getLanguageCode(langIndex) {
     const languageMap = {
       1: 'en',
-      2: 'en-GB',
-      3: 'es',
-      4: 'fr',
-      5: 'de'
+      2: 'fr',
+      3: 'nl',
+      4: 'es',
+      5: 'sv',
+      6: 'da',
+      7: 'de',
+      8: 'it',
+      9: 'cs'
     };
     return languageMap[langIndex] || 'en';
   }


### PR DESCRIPTION
## Bug

`getLanguageCode()` in `tx/cs/cs-snomed.js` (line 615) is not the inverse of `mapLanguageCode()` in `tx/importers/import-sct.module.js` (line 1478).

The importer reads ISO-639-1 `languageCode` values from [SNOMED CT RF2 Description files](https://docs.snomed.org/snomed-ct-specifications/snomed-ct-release-file-specification/component-release-file-specification/4.2-file-format-specifications/4.2.2-description-file-specification) and maps them to internal byte values:

```js
// mapLanguageCode() — import-sct.module.js:1478
'en': 1, 'en-US': 1, 'en-GB': 1,
'fr': 2, 'nl': 3, 'es': 4, 'sv': 5,
'da': 6, 'de': 7, 'it': 8, 'cs': 9
```

The output function should reverse this mapping, but does not:

```js
// getLanguageCode() — cs-snomed.js:615 (before fix)
1: 'en', 2: 'en-GB', 3: 'es', 4: 'fr', 5: 'de'
```

## Impact on tx.fhir.org

All non-English SNOMED CT designations are returned with **wrong language codes**:

| Byte | Before (wrong) | After (correct) | Effect |
|------|---------------|-----------------|--------|
| 1 | `en` | `en` | — |
| 2 | `en-GB` | `fr` | French tagged as British English |
| 3 | `es` | `nl` | **Dutch tagged as Spanish** |
| 4 | `fr` | `es` | Spanish tagged as French |
| 5 | `de` | `sv` | Swedish tagged as German |
| 6 | `en` (fallback) | `da` | Danish invisible |
| 7 | `en` (fallback) | `de` | German invisible |
| 8 | `en` (fallback) | `it` | Italian invisible |
| 9 | `en` (fallback) | `cs` | Czech invisible |

## Evidence

The SNOMED International Snowstorm API ([snowstorm.ihtsdotools.org](https://snowstorm.ihtsdotools.org)) confirms the RF2 source data uses `lang="nl"` for Dutch descriptions. For example, concept `405623001` has description `"toegewezen behandelaar"` with `lang: "nl"` in the RF2 data. tx.fhir.org currently returns this as `language: "es"`:

```
GET https://tx.fhir.org/r4/CodeSystem/$lookup?system=http://snomed.info/sct&code=405623001&version=http://snomed.info/sct/11000146104

→ designation.language: "es"
→ designation.value: "toegewezen behandelaar"   ← This is Dutch, not Spanish
```

## Fix

Replace the `getLanguageCode()` mapping with the correct inverse of `mapLanguageCode()`.