### PR TITLE
feat(ocl): canonical resolution via $resolveReference (ConceptMap/ValueSet sources, released-version default)

### DIFF
--- a/tests/ocl/ocl-cm-provider.test.js
+++ b/tests/ocl/ocl-cm-provider.test.js
@@ -525,6 +525,57 @@ describe('OCLConceptMapProvider $resolveReference integration', () => {
     expect(getPaths(httpClient)).toContain(SEARCH_ENDPOINT);
   });
 
+  it('resolves mapping source canonicals in one batch, not one GET per source', async () => {
+    // Flow: resolve source-system (1 ref) -> fetch {source}/mappings/ -> resolve
+    // the from/to source canonicals of the mappings in a single batched POST.
+    const post = jest.fn(async (path, body) => ({
+      data: body.map(ref => {
+        const url = typeof ref === 'string' ? ref : ref.url;
+        const repo = url.startsWith('/') ? url : '/orgs/TestOrg/sources/A/';
+        return {
+          reference_type: url.startsWith('/') ? 'relative' : 'canonical',
+          resolved: true,
+          result: {
+            url: repo,
+            owner_type: 'Organization',
+            type: 'Source',
+            canonical_url: `http://canon.example.org${repo}`
+          }
+        };
+      })
+    }));
+    const get = jest.fn(async (url) => {
+      if (url.endsWith('/mappings/')) {
+        return {
+          data: [makeMapping({
+            from_source_url: '/orgs/TestOrg/sources/SourceA/',
+            to_source_url: '/orgs/TestOrg/sources/SourceB/'
+          })]
+        };
+      }
+      return { data: [] };
+    });
+    const { provider, httpClient } = makeProvider({ post });
+    httpClient.get = get;
+    provider.httpClient.get = get;
+
+    const results = await provider.searchConceptMaps(searchParams);
+
+    // POST #1 resolves the source-system; POST #2 is the batch with BOTH
+    // mapping source paths in one request.
+    expect(post).toHaveBeenCalledTimes(2);
+    expect(post.mock.calls[1][1]).toEqual([
+      '/orgs/TestOrg/sources/SourceA/',
+      '/orgs/TestOrg/sources/SourceB/'
+    ]);
+    // No per-source detail GETs: only the mappings listing was fetched.
+    const detailGets = get.mock.calls.filter(c => /\/sources\/Source[AB]\/$/.test(c[0]));
+    expect(detailGets).toHaveLength(0);
+    // Aggregation used the canonicals from the batch.
+    expect(results).toHaveLength(1);
+    expect(results[0].jsonObj.group[0].source).toBe('http://canon.example.org/orgs/TestOrg/sources/SourceA/');
+  });
+
   // Regression: searchConceptMaps used to lower-case every param value. The old
   // text search tolerated it (#norm lower-cases anyway), but $resolveReference
   // matches the canonical exactly, so a lower-cased URL never resolved.

--- a/tests/ocl/ocl-cm-provider.test.js
+++ b/tests/ocl/ocl-cm-provider.test.js
@@ -214,6 +214,11 @@ describe('OCLConceptMapProvider', () => {
       ];
 
       const getMock = jest.fn().mockImplementation((url) => {
+        // {source}/mappings/ — one request returns every mapping the source owns.
+        // Must precede the '/sources/' branch below, which would otherwise swallow it.
+        if (url.endsWith('/mappings/') && !url.includes('/concepts/')) {
+          return Promise.resolve({ data: mappings });
+        }
         // source search — resolve canonical for SourceA
         if (url.includes('/sources/') && !url.includes('/concepts/')) {
           return Promise.resolve({
@@ -468,7 +473,7 @@ describe('OCLConceptMapProvider $resolveReference integration', () => {
     expect(httpClient.post).toHaveBeenCalledTimes(1);
     // The authoritative answer makes the q= text search unnecessary.
     expect(getPaths(httpClient)).not.toContain(SEARCH_ENDPOINT);
-    expect(getPaths(httpClient)).toContain('/orgs/OtherOrg/sources/S/concepts/');
+    expect(getPaths(httpClient)).toContain('/orgs/OtherOrg/sources/S/mappings/');
   });
 
   it('falls back to the source search when the canonical resolves to a user-owned repo', async () => {
@@ -485,7 +490,7 @@ describe('OCLConceptMapProvider $resolveReference integration', () => {
 
     await provider.searchConceptMaps(searchParams);
 
-    expect(getPaths(httpClient)).not.toContain('/users/joe/sources/S/concepts/');
+    expect(getPaths(httpClient)).not.toContain('/users/joe/sources/S/mappings/');
     expect(getPaths(httpClient)).toContain(SEARCH_ENDPOINT);
   });
 

--- a/tests/ocl/ocl-cm-provider.test.js
+++ b/tests/ocl/ocl-cm-provider.test.js
@@ -411,3 +411,113 @@ describe('OCLConceptMapProvider', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------
+// $resolveReference integration
+// ---------------------------------------------------------------
+describe('OCLConceptMapProvider $resolveReference integration', () => {
+  const { OclReferenceResolver } = require('../../tx/ocl/resolve/reference-resolver');
+
+  const SEARCH_ENDPOINT = '/orgs/TestOrg/sources/';
+
+  function makeProvider({ token = 'Token abc', post } = {}) {
+    const provider = new OCLConceptMapProvider({ org: 'TestOrg', token });
+    const httpClient = {
+      get: jest.fn(async () => ({ data: [] })),
+      post: post || jest.fn(async () => ({ data: [] }))
+    };
+    // The provider captures httpClient at construction, so rebuild the resolver
+    // on the mock the same way the other tests swap httpClient.
+    provider.httpClient = httpClient;
+    provider.referenceResolver = new OclReferenceResolver({
+      httpClient,
+      token,
+      logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+    });
+    return { provider, httpClient };
+  }
+
+  function resolveReferenceReply(url) {
+    return jest.fn(async () => ({
+      data: [
+        {
+          reference_type: 'canonical',
+          resolved: true,
+          request: null,
+          resolution_url: url,
+          url_registry_entry: null,
+          result: { type: 'Source', short_code: 'S', url, canonical_url: 'http://x.org/cs', owner_type: 'Organization' }
+        }
+      ]
+    }));
+  }
+
+  function getPaths(httpClient) {
+    return httpClient.get.mock.calls.map(call => call[0]);
+  }
+
+  const searchParams = [{ name: 'source-system', value: 'http://x.org/cs' }];
+
+  it('uses the resolved repo and skips the heuristic source search', async () => {
+    const { provider, httpClient } = makeProvider({
+      post: resolveReferenceReply('/users/joe/sources/S/')
+    });
+
+    await provider.searchConceptMaps(searchParams);
+
+    expect(httpClient.post).toHaveBeenCalledTimes(1);
+    // The authoritative answer makes the q= text search unnecessary.
+    expect(getPaths(httpClient)).not.toContain(SEARCH_ENDPOINT);
+    // ...and a user-owned repo survives, which an /orgs/-only filter would drop.
+    expect(getPaths(httpClient)).toContain('/users/joe/sources/S/concepts/');
+  });
+
+  it('falls back to the source search when no token is configured', async () => {
+    const { provider, httpClient } = makeProvider({ token: null });
+
+    await provider.searchConceptMaps(searchParams);
+
+    expect(httpClient.post).not.toHaveBeenCalled();
+    expect(getPaths(httpClient)).toContain(SEARCH_ENDPOINT);
+  });
+
+  it('falls back to the source search when OCL cannot resolve the canonical', async () => {
+    const post = jest.fn(async () => ({
+      data: [{ reference_type: 'canonical', resolved: false, result: null }]
+    }));
+    const { provider, httpClient } = makeProvider({ post });
+
+    await provider.searchConceptMaps(searchParams);
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(getPaths(httpClient)).toContain(SEARCH_ENDPOINT);
+  });
+
+  it('falls back to the source search when $resolveReference is unavailable', async () => {
+    const error = new Error('Request failed with status code 404');
+    error.response = { status: 404 };
+    const { provider, httpClient } = makeProvider({ post: jest.fn().mockRejectedValue(error) });
+
+    await provider.searchConceptMaps(searchParams);
+
+    expect(getPaths(httpClient)).toContain(SEARCH_ENDPOINT);
+  });
+
+  // Regression: searchConceptMaps used to lower-case every param value. The old
+  // text search tolerated it (#norm lower-cases anyway), but $resolveReference
+  // matches the canonical exactly, so a lower-cased URL never resolved.
+  it('sends the canonical to $resolveReference with its original casing', async () => {
+    const { provider, httpClient } = makeProvider({
+      post: resolveReferenceReply('/orgs/Mangara/sources/S/')
+    });
+
+    await provider.searchConceptMaps([
+      { name: 'source-system', value: 'https://mangara.hsl.org.br/fhir/CodeSystem/AlcoolSPA_uso_Mangara' }
+    ]);
+
+    expect(httpClient.post).toHaveBeenCalledTimes(1);
+    expect(httpClient.post.mock.calls[0][1]).toEqual([
+      'https://mangara.hsl.org.br/fhir/CodeSystem/AlcoolSPA_uso_Mangara'
+    ]);
+  });
+});

--- a/tests/ocl/ocl-cm-provider.test.js
+++ b/tests/ocl/ocl-cm-provider.test.js
@@ -460,7 +460,7 @@ describe('OCLConceptMapProvider $resolveReference integration', () => {
 
   it('uses the resolved repo and skips the heuristic source search', async () => {
     const { provider, httpClient } = makeProvider({
-      post: resolveReferenceReply('/users/joe/sources/S/')
+      post: resolveReferenceReply('/orgs/OtherOrg/sources/S/')
     });
 
     await provider.searchConceptMaps(searchParams);
@@ -468,8 +468,25 @@ describe('OCLConceptMapProvider $resolveReference integration', () => {
     expect(httpClient.post).toHaveBeenCalledTimes(1);
     // The authoritative answer makes the q= text search unnecessary.
     expect(getPaths(httpClient)).not.toContain(SEARCH_ENDPOINT);
-    // ...and a user-owned repo survives, which an /orgs/-only filter would drop.
-    expect(getPaths(httpClient)).toContain('/users/joe/sources/S/concepts/');
+    expect(getPaths(httpClient)).toContain('/orgs/OtherOrg/sources/S/concepts/');
+  });
+
+  it('falls back to the source search when the canonical resolves to a user-owned repo', async () => {
+    // Org-only policy: user artifacts are experimental and not visible through
+    // the terminology service, so the resolver reports them as unresolved.
+    const post = jest.fn(async () => ({
+      data: [{
+        reference_type: 'canonical',
+        resolved: true,
+        result: { url: '/users/joe/sources/S/', owner_type: 'User', canonical_url: 'http://x.org/cs' }
+      }]
+    }));
+    const { provider, httpClient } = makeProvider({ post });
+
+    await provider.searchConceptMaps(searchParams);
+
+    expect(getPaths(httpClient)).not.toContain('/users/joe/sources/S/concepts/');
+    expect(getPaths(httpClient)).toContain(SEARCH_ENDPOINT);
   });
 
   it('falls back to the source search when no token is configured', async () => {

--- a/tests/ocl/ocl-cs-default-version.test.js
+++ b/tests/ocl/ocl-cs-default-version.test.js
@@ -110,6 +110,22 @@ describe('OCL CodeSystem default-version resolution', () => {
     expect(metas.map(m => m.version)).toEqual(['HEAD']);
   });
 
+  it('does not re-resolve unchanged canonicals on refresh (steady state costs nothing)', async () => {
+    const { provider, httpClient } = makeProvider();
+
+    await provider.listCodeSystems('5.0', null);
+    expect(httpClient.post).toHaveBeenCalledTimes(1);
+
+    // Minute refresh with an unchanged listing: same checksum, no new resolve.
+    provider.getCodeSystemChanges('5.0', null);
+    await new Promise(resolve => setTimeout(resolve, 150));
+
+    expect(httpClient.get.mock.calls.filter(c => c[0] === '/sources/').length).toBeGreaterThanOrEqual(2);
+    expect(httpClient.post).toHaveBeenCalledTimes(1);
+    // The release default survived the refresh.
+    expect(provider.getSourceMetas().map(m => m.version)).toEqual(['20230109', 'HEAD']);
+  });
+
   it('keeps discovery working when $resolveReference is unavailable', async () => {
     const error = new Error('Request failed with status code 404');
     error.response = { status: 404 };

--- a/tests/ocl/ocl-cs-default-version.test.js
+++ b/tests/ocl/ocl-cs-default-version.test.js
@@ -1,0 +1,125 @@
+// Default-version resolution for OCL CodeSystems: OCL's own resolution says the
+// latest RELEASE is a source's default version (HEAD only when nothing is
+// released), but discovery listings only ever report HEAD. With a token, the
+// provider batch-resolves every canonical via $resolveReference and registers
+// BOTH versions — the release as the default (what a versionless request gets)
+// and HEAD as an explicit |HEAD variant.
+
+const { OCLCodeSystemProvider } = require('../../tx/ocl/cs-ocl');
+const { OclReferenceResolver } = require('../../tx/ocl/resolve/reference-resolver');
+
+const CANONICAL = 'https://gov.br/anvisa/fhir/CodeSystem/cmed';
+
+function cmedSource() {
+  return {
+    id: 'cmed',
+    short_code: 'cmed',
+    owner: 'ANVISA',
+    owner_type: 'Organization',
+    url: '/orgs/ANVISA/sources/cmed/',
+    canonical_url: CANONICAL,
+    version: 'HEAD',
+    concepts_url: '/orgs/ANVISA/sources/cmed/concepts/',
+    checksums: { standard: 'x' },
+    updated_at: '2026-01-01T00:00:00Z'
+  };
+}
+
+// $resolveReference reply: default version is the released 20230109.
+function releaseReply() {
+  return {
+    reference_type: 'canonical',
+    resolved: true,
+    result: {
+      url: '/orgs/ANVISA/sources/cmed/',
+      owner: 'ANVISA',
+      owner_type: 'Organization',
+      version: '20230109',
+      type: 'Source Version',
+      canonical_url: CANONICAL
+    }
+  };
+}
+
+function makeProvider({ token = 'Token x', post } = {}) {
+  const provider = new OCLCodeSystemProvider({ baseUrl: 'https://ocl.example.org', token });
+  const httpClient = {
+    get: jest.fn(async (url) => {
+      if (url === '/sources/') {
+        return { data: { results: [cmedSource()], num_found: 1 } };
+      }
+      return { data: [] };
+    }),
+    post: post || jest.fn(async () => ({ data: [releaseReply()] }))
+  };
+  provider.httpClient = httpClient;
+  provider.referenceResolver = new OclReferenceResolver({
+    httpClient, token, logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+  });
+  return { provider, httpClient };
+}
+
+describe('OCL CodeSystem default-version resolution', () => {
+  it('registers the release as default and keeps HEAD as an explicit variant', async () => {
+    const { provider, httpClient } = makeProvider();
+
+    const listed = await provider.listCodeSystems('5.0', null);
+    const metas = provider.getSourceMetas();
+
+    // One batched $resolveReference for the discovered canonicals.
+    expect(httpClient.post).toHaveBeenCalledTimes(1);
+    expect(httpClient.post.mock.calls[0][1]).toEqual([CANONICAL]);
+
+    // The listed CodeSystem is the release, not the HEAD draft.
+    expect(listed).toHaveLength(1);
+    expect(listed[0].jsonObj.version).toBe('20230109');
+
+    // Both versions exist; the release comes FIRST so registerProvider's
+    // first-wins unversioned key makes it the versionless default.
+    expect(metas.map(m => m.version)).toEqual(['20230109', 'HEAD']);
+    expect(metas[0].conceptsUrl).toBe('/orgs/ANVISA/sources/cmed/20230109/concepts/');
+    expect(metas[1].conceptsUrl).toBe('/orgs/ANVISA/sources/cmed/concepts/');
+    expect(metas[0].canonicalUrl).toBe(CANONICAL);
+  });
+
+  it('stays HEAD-only without a token (behaviour unchanged)', async () => {
+    const { provider, httpClient } = makeProvider({ token: null });
+
+    const listed = await provider.listCodeSystems('5.0', null);
+    const metas = provider.getSourceMetas();
+
+    expect(httpClient.post).not.toHaveBeenCalled();
+    expect(listed[0].jsonObj.version).toBe('HEAD');
+    expect(metas.map(m => m.version)).toEqual(['HEAD']);
+  });
+
+  it('stays HEAD-only when HEAD is the default (nothing released)', async () => {
+    const post = jest.fn(async () => ({
+      data: [{
+        reference_type: 'canonical',
+        resolved: true,
+        result: { url: '/orgs/ANVISA/sources/cmed/', owner_type: 'Organization', version: 'HEAD', type: 'Source', canonical_url: CANONICAL }
+      }]
+    }));
+    const { provider } = makeProvider({ post });
+
+    const listed = await provider.listCodeSystems('5.0', null);
+    const metas = provider.getSourceMetas();
+
+    expect(listed[0].jsonObj.version).toBe('HEAD');
+    expect(metas.map(m => m.version)).toEqual(['HEAD']);
+  });
+
+  it('keeps discovery working when $resolveReference is unavailable', async () => {
+    const error = new Error('Request failed with status code 404');
+    error.response = { status: 404 };
+    const { provider } = makeProvider({ post: jest.fn().mockRejectedValue(error) });
+
+    const listed = await provider.listCodeSystems('5.0', null);
+    const metas = provider.getSourceMetas();
+
+    // Falls back to HEAD-only — never blocks discovery.
+    expect(listed).toHaveLength(1);
+    expect(metas.map(m => m.version)).toEqual(['HEAD']);
+  });
+});

--- a/tests/ocl/ocl-discovery-global.test.js
+++ b/tests/ocl/ocl-discovery-global.test.js
@@ -1,0 +1,109 @@
+// Global-listing discovery: one paginated crawl of /sources/ (or /collections/)
+// filtered to organization-owned entries, with the per-org enumeration kept as
+// fallback when the global listing is unavailable or empty.
+
+const { OCLCodeSystemProvider } = require('../../tx/ocl/cs-ocl');
+const { OCLValueSetProvider } = require('../../tx/ocl/vs-ocl');
+
+function orgSource(id, canonical) {
+  return {
+    id, short_code: id, owner: 'MS', owner_type: 'Organization',
+    url: `/orgs/MS/sources/${id}/`, canonical_url: canonical,
+    version: 'HEAD', concepts_url: `/orgs/MS/sources/${id}/concepts/`,
+    checksums: { standard: 'x' }, updated_at: '2026-01-01T00:00:00Z'
+  };
+}
+
+function userSource(id, canonical) {
+  return {
+    ...orgSource(id, canonical),
+    owner: 'joe', owner_type: 'User', url: `/users/joe/sources/${id}/`
+  };
+}
+
+describe('CodeSystem discovery via the global listing', () => {
+  it('uses one global crawl and filters out user-owned sources (org-only policy)', async () => {
+    const provider = new OCLCodeSystemProvider({ baseUrl: 'https://ocl.example.org' });
+    const get = jest.fn(async (url) => {
+      if (url === '/sources/') {
+        return {
+          data: {
+            results: [
+              orgSource('A', 'http://x.org/cs/A'),
+              userSource('B', 'http://x.org/cs/B'),
+              orgSource('C', 'http://x.org/cs/C')
+            ],
+            num_found: 3
+          }
+        };
+      }
+      return { data: [] };
+    });
+    provider.httpClient = { get, post: jest.fn() };
+
+    const listed = await provider.listCodeSystems('5.0', null);
+
+    const urls = listed.map(cs => cs.url).sort();
+    expect(urls).toEqual(['http://x.org/cs/A', 'http://x.org/cs/C']);
+    // No per-org enumeration: /orgs/ was never listed.
+    expect(get.mock.calls.some(c => c[0] === '/orgs/')).toBe(false);
+  });
+
+  it('falls back to per-org enumeration when the global listing fails', async () => {
+    const provider = new OCLCodeSystemProvider({ baseUrl: 'https://ocl.example.org' });
+    const get = jest.fn(async (url) => {
+      if (url === '/sources/') {
+        const error = new Error('boom');
+        error.response = { status: 500 };
+        throw error;
+      }
+      if (url === '/orgs/') {
+        return { data: [{ id: 'MS' }] };
+      }
+      if (url === '/orgs/MS/sources/') {
+        return { data: { results: [orgSource('A', 'http://x.org/cs/A')], num_found: 1 } };
+      }
+      return { data: [] };
+    });
+    provider.httpClient = { get, post: jest.fn() };
+
+    const listed = await provider.listCodeSystems('5.0', null);
+
+    expect(listed.map(cs => cs.url)).toEqual(['http://x.org/cs/A']);
+    expect(get.mock.calls.some(c => c[0] === '/orgs/MS/sources/')).toBe(true);
+  });
+});
+
+describe('ValueSet discovery via the global listing', () => {
+  function orgCollection(id, canonical) {
+    return {
+      id, short_code: id, owner: 'MS', owner_type: 'Organization',
+      url: `/orgs/MS/collections/${id}/`, canonical_url: canonical, version: 'HEAD'
+    };
+  }
+
+  it('uses one global crawl and filters out user-owned collections', async () => {
+    const provider = new OCLValueSetProvider({ baseUrl: 'https://ocl.example.org' });
+    const get = jest.fn(async (url) => {
+      if (url === '/collections/') {
+        return {
+          data: {
+            results: [
+              orgCollection('VC1', 'http://x.org/vs/GlobalDiscoveryVC1'),
+              { ...orgCollection('VC2', 'http://x.org/vs/GlobalDiscoveryVC2'), owner: 'joe', owner_type: 'User', url: '/users/joe/collections/VC2/' }
+            ],
+            num_found: 2
+          }
+        };
+      }
+      return { data: [] };
+    });
+    provider.httpClient = { get, post: jest.fn() };
+
+    await provider.initialize();
+
+    expect(provider.valueSetMap.has('http://x.org/vs/GlobalDiscoveryVC1')).toBe(true);
+    expect(provider.valueSetMap.has('http://x.org/vs/GlobalDiscoveryVC2')).toBe(false);
+    expect(get.mock.calls.some(c => c[0] === '/orgs/')).toBe(false);
+  });
+});

--- a/tests/ocl/ocl-reference-resolver.test.js
+++ b/tests/ocl/ocl-reference-resolver.test.js
@@ -2,6 +2,7 @@ const {
   OclReferenceResolver,
   normalizeReference,
   isOclRepoPath,
+  isOrgOwned,
   RESOLVE_PATH
 } = require('../../tx/ocl/resolve/reference-resolver');
 
@@ -77,19 +78,20 @@ function httpError(status, data) {
   return error;
 }
 
-describe('isOclRepoPath', () => {
+describe('isOclRepoPath (org-only policy)', () => {
   it.each([
     ['/orgs/CIEL/sources/CIEL/'],
     ['/orgs/CIEL/sources/CIEL/HEAD/'],
     ['/orgs/CIEL/collections/C/'],
-    // The point: user-owned repos are real and must not be filtered out.
-    ['/users/joe/sources/S/'],
-    ['  /users/joe/sources/S/  ']
+    ['  /orgs/CIEL/sources/CIEL/  ']
   ])('accepts %s', input => {
     expect(isOclRepoPath(input)).toBe(true);
   });
 
   it.each([
+    // User-owned artifacts are experimental by convention: an artifact is
+    // expected to live in an org to be visible through the terminology service.
+    ['/users/joe/sources/S/'],
     ['http://loinc.org'],
     ['/sources/S/'],
     ['/orgs/'],
@@ -100,6 +102,23 @@ describe('isOclRepoPath', () => {
     [undefined]
   ])('rejects %p', input => {
     expect(isOclRepoPath(input)).toBe(false);
+  });
+});
+
+describe('isOrgOwned', () => {
+  it('prefers an explicit owner_type', () => {
+    expect(isOrgOwned({ owner_type: 'Organization', url: '/users/joe/sources/S/' })).toBe(true);
+    expect(isOrgOwned({ owner_type: 'User', url: '/orgs/A/sources/S/' })).toBe(false);
+    expect(isOrgOwned({ ownerType: 'Organization' })).toBe(true);
+  });
+
+  it('falls back to the path shape when owner_type is absent', () => {
+    expect(isOrgOwned({ url: '/orgs/A/sources/S/' })).toBe(true);
+    expect(isOrgOwned({ url: '/users/joe/sources/S/' })).toBe(false);
+  });
+
+  it.each([[null], [undefined], ['x'], [{}]])('rejects %p', input => {
+    expect(isOrgOwned(input)).toBe(false);
   });
 });
 
@@ -251,16 +270,24 @@ describe('OclReferenceResolver resolution', () => {
     expect(r.canonical).toBe('https://terminologia.saude.gov.br/fhir/CodeSystem/BRTabelaSUS');
   });
 
-  it('resolves a user-owned repo (an /orgs/-only filter would drop these)', async () => {
+  it('treats a canonical that resolves to a user-owned repo as unresolved (org-only policy)', async () => {
     const httpClient = {
-      post: jest.fn(async () => ({ data: [oclEntry({ url: '/users/joe/sources/S/' })] }))
+      post: jest.fn(async () => ({
+        data: [oclEntry({ url: '/users/joe/sources/S/', ownerType: 'User', owner: 'joe' })]
+      }))
     };
-    const resolver = makeResolver({ httpClient });
+    const logger = silentLogger();
+    const resolver = makeResolver({ httpClient, logger });
 
-    const result = await resolver.resolve('/users/joe/sources/S/');
+    const result = await resolver.resolve('http://joe.example.org/cs');
 
-    expect(result.repoUrl).toBe('/users/joe/sources/S/');
-    expect(isOclRepoPath(result.repoUrl)).toBe(true);
+    expect(result.resolved).toBe(false);
+    expect(result.repoUrl).toBeNull();
+    expect(logger.info).toHaveBeenCalledWith(expect.stringMatching(/user-owned repo.*org-only policy/));
+
+    // Policy outcome is deterministic: cached, no second round trip.
+    await resolver.resolve('http://joe.example.org/cs');
+    expect(httpClient.post).toHaveBeenCalledTimes(1);
   });
 
   it('returns an empty array and issues no request for no references', async () => {
@@ -312,7 +339,7 @@ describe('OclReferenceResolver resolution', () => {
       post: jest.fn(async () => ({
         data: [{
           resolved: true,
-          result: { url: '/orgs/A/sources/S/', canonicalUrl: 'http://a.org/cs', ownerType: 'User' }
+          result: { url: '/orgs/A/sources/S/', canonicalUrl: 'http://a.org/cs', ownerType: 'Organization' }
         }]
       }))
     };
@@ -321,7 +348,7 @@ describe('OclReferenceResolver resolution', () => {
     const r = await resolver.resolve('/orgs/A/sources/S/');
 
     expect(r.canonical).toBe('http://a.org/cs');
-    expect(r.ownerType).toBe('User');
+    expect(r.ownerType).toBe('Organization');
   });
 
   it("prefers OCL's own request echo over the submitted body", async () => {

--- a/tests/ocl/ocl-reference-resolver.test.js
+++ b/tests/ocl/ocl-reference-resolver.test.js
@@ -425,6 +425,36 @@ describe('OclReferenceResolver batching', () => {
   });
 });
 
+describe('OclReferenceResolver chunking', () => {
+  it('splits a large batch into POSTs of at most 100 and preserves order', async () => {
+    const httpClient = echoClient();
+    const resolver = makeResolver({ httpClient });
+    const refs = Array.from({ length: 250 }, (_, i) => `ref${i}`);
+
+    const results = await resolver.resolveReferences(refs);
+
+    expect(httpClient.post).toHaveBeenCalledTimes(3);
+    expect(httpClient.post.mock.calls.map(c => c[1].length)).toEqual([100, 100, 50]);
+    expect(results).toHaveLength(250);
+    expect(results[0].repoUrl).toBe('/orgs/X/sources/ref0/');
+    expect(results[249].repoUrl).toBe('/orgs/X/sources/ref249/');
+  });
+
+  it('bypassCache re-asks OCL and refreshes the cache', async () => {
+    const httpClient = echoClient();
+    const resolver = makeResolver({ httpClient });
+
+    await resolver.resolve('a');
+    await resolver.resolveReferences(['a'], { bypassCache: true });
+
+    expect(httpClient.post).toHaveBeenCalledTimes(2);
+
+    // Cache was refreshed, not invalidated: a third plain call is a cache hit.
+    await resolver.resolve('a');
+    expect(httpClient.post).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe('OclReferenceResolver caching', () => {
   it('serves a repeat reference from cache', async () => {
     const httpClient = echoClient();

--- a/tests/ocl/ocl-reference-resolver.test.js
+++ b/tests/ocl/ocl-reference-resolver.test.js
@@ -1,0 +1,506 @@
+const {
+  OclReferenceResolver,
+  normalizeReference,
+  isOclRepoPath,
+  RESOLVE_PATH
+} = require('../../tx/ocl/resolve/reference-resolver');
+
+function silentLogger() {
+  return { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+}
+
+// One entry of OCL's $resolveReference response.
+//
+// Shaped from a real response captured against oclapi2.ips.hsl.org.br, NOT from
+// the docs — the documented example shows only {type, short_code, url}, but the
+// live payload carries canonical_url, owner_type, version and checksums, and
+// reports type "Source" rather than "Source Version".
+function oclEntry({
+  resolved = true,
+  url = '/orgs/MS/sources/BRTabelaSUS/',
+  canonicalUrl = 'https://terminologia.saude.gov.br/fhir/CodeSystem/BRTabelaSUS',
+  owner = 'MS',
+  ownerType = 'Organization',
+  registryEntry = null,
+  referenceType = 'relative',
+  resolutionUrl = null,
+  request = null
+} = {}) {
+  return {
+    reference_type: referenceType,
+    timestamp: '2026-07-15T17:25:44.682776',
+    resolved,
+    request,
+    resolution_url: resolutionUrl,
+    url_registry_entry: registryEntry,
+    result: resolved
+      ? {
+        short_code: url.split('/').filter(Boolean).pop(),
+        name: url.split('/').filter(Boolean).pop(),
+        url,
+        owner,
+        owner_type: ownerType,
+        owner_url: `/orgs/${owner}/`,
+        version: 'HEAD',
+        source_type: 'Dictionary',
+        canonical_url: canonicalUrl,
+        type: 'Source',
+        checksums: { standard: '282d3c8ce440b8a03698196967042a08', smart: '90599db3f6da397c1af26baaf9467eb1' }
+      }
+      : null
+  };
+}
+
+// Echoes one result per submitted ref, tagging the url so ordering is assertable.
+function echoClient() {
+  return {
+    post: jest.fn(async (path, body) => ({
+      data: body.map(ref => {
+        const url = typeof ref === 'string' ? ref : ref.url;
+        return oclEntry({ url: `/orgs/X/sources/${url}/`, request: ref });
+      })
+    }))
+  };
+}
+
+function makeResolver({ httpClient, logger, token = 'Token abc' } = {}) {
+  return new OclReferenceResolver({
+    httpClient: httpClient || echoClient(),
+    logger: logger || silentLogger(),
+    token
+  });
+}
+
+function httpError(status, data) {
+  const error = new Error(`Request failed with status code ${status}`);
+  error.response = { status, data };
+  return error;
+}
+
+describe('isOclRepoPath', () => {
+  it.each([
+    ['/orgs/CIEL/sources/CIEL/'],
+    ['/orgs/CIEL/sources/CIEL/HEAD/'],
+    ['/orgs/CIEL/collections/C/'],
+    // The point: user-owned repos are real and must not be filtered out.
+    ['/users/joe/sources/S/'],
+    ['  /users/joe/sources/S/  ']
+  ])('accepts %s', input => {
+    expect(isOclRepoPath(input)).toBe(true);
+  });
+
+  it.each([
+    ['http://loinc.org'],
+    ['/sources/S/'],
+    ['/orgs/'],
+    ['/orgs/CIEL'],
+    ['/groups/x/sources/S/'],
+    [''],
+    [null],
+    [undefined]
+  ])('rejects %p', input => {
+    expect(isOclRepoPath(input)).toBe(false);
+  });
+});
+
+describe('normalizeReference', () => {
+  it('passes a relative path string through as a string', () => {
+    expect(normalizeReference('/orgs/CIEL/sources/CIEL/')).toBe('/orgs/CIEL/sources/CIEL/');
+  });
+
+  it('keeps the expanded object fields', () => {
+    expect(normalizeReference({
+      url: 'http://hl7.org/fhir/CodeSystem/x',
+      version: '0.8',
+      code: '1948',
+      resourceType: 'Mapping'
+    })).toEqual({
+      url: 'http://hl7.org/fhir/CodeSystem/x',
+      version: '0.8',
+      code: '1948',
+      resourceType: 'Mapping'
+    });
+  });
+
+  it('never emits a namespace field (global-namespace only by design)', () => {
+    const body = normalizeReference({ url: '/orgs/A/sources/S/', namespace: '/orgs/A/' });
+    expect(body).not.toHaveProperty('namespace');
+  });
+
+  it('drops null and undefined fields', () => {
+    expect(normalizeReference({ url: 'x', version: null, code: undefined })).toEqual({ url: 'x' });
+  });
+
+  it.each([[''], ['   ']])('rejects the empty string %p', input => {
+    expect(() => normalizeReference(input)).toThrow(/cannot be empty/);
+  });
+
+  it.each([[{}], [{ url: '' }], [{ url: null }]])('rejects object %p without a url', input => {
+    expect(() => normalizeReference(input)).toThrow(/requires a url/);
+  });
+
+  it.each([[null], [undefined], [123], [[]]])('rejects %p', input => {
+    expect(() => normalizeReference(input)).toThrow(/Invalid OCL reference/);
+  });
+});
+
+describe('OclReferenceResolver construction', () => {
+  it('requires an http client', () => {
+    expect(() => new OclReferenceResolver({ token: 'Token abc' })).toThrow(/requires an http client/);
+  });
+
+  // $resolveReference is auth-gated on every instance probed, while the listing
+  // endpoints it replaces are public — a tokenless call is a guaranteed 401.
+  it('stays disabled without a token and issues no request', async () => {
+    const httpClient = echoClient();
+    const resolver = makeResolver({ httpClient, token: null });
+
+    expect(resolver.isEnabled()).toBe(false);
+    expect(resolver.disabledReason).toBe('no token configured');
+    await expect(resolver.resolveReferences(['/orgs/A/sources/S/'])).resolves.toBeNull();
+    expect(httpClient.post).not.toHaveBeenCalled();
+  });
+
+  it('is enabled with a token', () => {
+    expect(makeResolver().isEnabled()).toBe(true);
+  });
+});
+
+describe('OclReferenceResolver resolution', () => {
+  it('resolves a single relative reference', async () => {
+    const httpClient = {
+      post: jest.fn(async () => ({ data: [oclEntry({ url: '/orgs/CIEL/sources/CIEL/' })] }))
+    };
+    const resolver = makeResolver({ httpClient });
+
+    const result = await resolver.resolve('/orgs/CIEL/sources/CIEL/');
+
+    expect(result.resolved).toBe(true);
+    expect(result.repoUrl).toBe('/orgs/CIEL/sources/CIEL/');
+    expect(httpClient.post).toHaveBeenCalledWith(RESOLVE_PATH, ['/orgs/CIEL/sources/CIEL/']);
+  });
+
+  it('resolves an expanded object reference with a version', async () => {
+    const httpClient = {
+      post: jest.fn(async () => ({ data: [oclEntry({ referenceType: 'canonical' })] }))
+    };
+    const resolver = makeResolver({ httpClient });
+
+    const result = await resolver.resolve({ url: 'http://hl7.org/fhir/CodeSystem/x', version: '0.8' });
+
+    expect(result.resolved).toBe(true);
+    expect(result.referenceType).toBe('canonical');
+    expect(httpClient.post).toHaveBeenCalledWith(
+      RESOLVE_PATH,
+      [{ url: 'http://hl7.org/fhir/CodeSystem/x', version: '0.8' }]
+    );
+  });
+
+  // Verbatim response captured from oclapi2.ips.hsl.org.br for
+  // POST /$resolveReference/ ["/orgs/MS/sources/BRTabelaSUS/concepts/1948/"].
+  // Guards against the doc's example, which omits most of these fields.
+  it('handles a real relative-reference response, concept and all', async () => {
+    const live = [{
+      reference_type: 'relative',
+      resolved: true,
+      timestamp: '2026-07-15T17:25:44.682776',
+      request: '/orgs/MS/sources/BRTabelaSUS/concepts/1948/',
+      resolution_url: '/orgs/MS/sources/BRTabelaSUS/',
+      url_registry_entry: null,
+      result: {
+        short_code: 'BRTabelaSUS',
+        name: 'BRTabelaSUS',
+        url: '/orgs/MS/sources/BRTabelaSUS/',
+        owner: 'MS',
+        owner_type: 'Organization',
+        owner_url: '/orgs/MS/',
+        version: 'HEAD',
+        created_at: '2025-10-24T12:41:29.742565Z',
+        id: 'BRTabelaSUS',
+        source_type: 'Dictionary',
+        updated_at: '2026-06-22T15:25:14.276339Z',
+        canonical_url: 'https://terminologia.saude.gov.br/fhir/CodeSystem/BRTabelaSUS',
+        type: 'Source',
+        checksums: { standard: '282d3c8ce440b8a03698196967042a08', smart: '90599db3f6da397c1af26baaf9467eb1' }
+      }
+    }];
+    const httpClient = { post: jest.fn(async () => ({ data: live })) };
+    const resolver = makeResolver({ httpClient });
+
+    const r = await resolver.resolve('/orgs/MS/sources/BRTabelaSUS/concepts/1948/');
+
+    expect(r.resolved).toBe(true);
+    expect(r.repoUrl).toBe('/orgs/MS/sources/BRTabelaSUS/');
+    expect(r.referenceType).toBe('relative');
+    // OCL strips the concept: the reference points at a concept, the repo is the source.
+    expect(r.resolutionUrl).toBe('/orgs/MS/sources/BRTabelaSUS/');
+    expect(r.canonical).toBe('https://terminologia.saude.gov.br/fhir/CodeSystem/BRTabelaSUS');
+    expect(r.ownerType).toBe('Organization');
+    expect(r.registryEntry).toBeNull();
+    // The raw result stays available for anything we don't surface.
+    expect(r.result.checksums.standard).toBe('282d3c8ce440b8a03698196967042a08');
+  });
+
+  it('surfaces the repo canonical_url rather than echoing the requested spelling', async () => {
+    const httpClient = { post: jest.fn(async () => ({ data: [oclEntry()] })) };
+    const resolver = makeResolver({ httpClient });
+
+    // Asked with a different spelling (http) than the repo's own canonical (https).
+    const r = await resolver.resolve('http://terminologia.saude.gov.br/fhir/CodeSystem/BRTabelaSUS');
+
+    expect(r.canonical).toBe('https://terminologia.saude.gov.br/fhir/CodeSystem/BRTabelaSUS');
+  });
+
+  it('resolves a user-owned repo (an /orgs/-only filter would drop these)', async () => {
+    const httpClient = {
+      post: jest.fn(async () => ({ data: [oclEntry({ url: '/users/joe/sources/S/' })] }))
+    };
+    const resolver = makeResolver({ httpClient });
+
+    const result = await resolver.resolve('/users/joe/sources/S/');
+
+    expect(result.repoUrl).toBe('/users/joe/sources/S/');
+    expect(isOclRepoPath(result.repoUrl)).toBe(true);
+  });
+
+  it('returns an empty array and issues no request for no references', async () => {
+    const httpClient = echoClient();
+    const resolver = makeResolver({ httpClient });
+
+    await expect(resolver.resolveReferences([])).resolves.toEqual([]);
+    expect(httpClient.post).not.toHaveBeenCalled();
+  });
+
+  it('reports resolved:false without throwing (OCL returns 200, not an error)', async () => {
+    const httpClient = { post: jest.fn(async () => ({ data: [oclEntry({ resolved: false })] })) };
+    const resolver = makeResolver({ httpClient });
+
+    const result = await resolver.resolve('/orgs/nope/sources/nope/');
+
+    expect(result.resolved).toBe(false);
+    expect(result.repoUrl).toBeNull();
+  });
+
+  it('treats a resolved flag with no result url as unresolved', async () => {
+    const httpClient = { post: jest.fn(async () => ({ data: [{ resolved: true, result: null }] })) };
+    const resolver = makeResolver({ httpClient });
+
+    await expect(resolver.resolve('/orgs/A/sources/S/')).resolves.toMatchObject({ resolved: false });
+  });
+
+  it.each([[null], ['oops'], [42]])('treats a malformed result entry %p as unresolved', async entry => {
+    const httpClient = { post: jest.fn(async () => ({ data: [entry] })) };
+    const resolver = makeResolver({ httpClient });
+
+    const result = await resolver.resolve('/orgs/A/sources/S/');
+
+    expect(result.resolved).toBe(false);
+    expect(result.repoUrl).toBeNull();
+  });
+
+  it('tolerates a non-array response body', async () => {
+    const httpClient = { post: jest.fn(async () => ({ data: oclEntry({ url: '/orgs/A/sources/S/' }) })) };
+    const resolver = makeResolver({ httpClient });
+
+    const result = await resolver.resolve('/orgs/A/sources/S/');
+
+    expect(result.repoUrl).toBe('/orgs/A/sources/S/');
+  });
+
+  it('reads camelCase result fields as a fallback', async () => {
+    const httpClient = {
+      post: jest.fn(async () => ({
+        data: [{
+          resolved: true,
+          result: { url: '/orgs/A/sources/S/', canonicalUrl: 'http://a.org/cs', ownerType: 'User' }
+        }]
+      }))
+    };
+    const resolver = makeResolver({ httpClient });
+
+    const r = await resolver.resolve('/orgs/A/sources/S/');
+
+    expect(r.canonical).toBe('http://a.org/cs');
+    expect(r.ownerType).toBe('User');
+  });
+
+  it("prefers OCL's own request echo over the submitted body", async () => {
+    const httpClient = {
+      post: jest.fn(async () => ({
+        data: [{ ...oclEntry(), request: { url: 'echoed-by-ocl' } }]
+      }))
+    };
+    const resolver = makeResolver({ httpClient });
+
+    const r = await resolver.resolve('/orgs/A/sources/S/');
+
+    expect(r.request).toEqual({ url: 'echoed-by-ocl' });
+  });
+
+  it('accepts a single non-array reference in resolveReferences', async () => {
+    const httpClient = echoClient();
+    const resolver = makeResolver({ httpClient });
+
+    const results = await resolver.resolveReferences('a');
+
+    expect(results).toHaveLength(1);
+    expect(results[0].repoUrl).toBe('/orgs/X/sources/a/');
+  });
+
+  it('resolve() returns null when the resolver is unavailable', async () => {
+    const resolver = makeResolver({ token: null });
+    await expect(resolver.resolve('/orgs/A/sources/S/')).resolves.toBeNull();
+  });
+
+  it('treats a null response data as a misaligned batch', async () => {
+    const httpClient = { post: jest.fn(async () => ({ data: null })) };
+    const logger = silentLogger();
+    const resolver = makeResolver({ httpClient, logger });
+
+    const result = await resolver.resolve('/orgs/A/sources/S/');
+
+    expect(result.resolved).toBe(false);
+    expect(logger.error).toHaveBeenCalledWith(expect.stringMatching(/misaligned/));
+  });
+});
+
+describe('OclReferenceResolver batching', () => {
+  it('sends the whole batch as ONE POST and preserves caller order', async () => {
+    const httpClient = echoClient();
+    const resolver = makeResolver({ httpClient });
+
+    const results = await resolver.resolveReferences(['a', { url: 'b', version: '1.0' }, 'c']);
+
+    expect(httpClient.post).toHaveBeenCalledTimes(1);
+    expect(httpClient.post.mock.calls[0][1]).toEqual(['a', { url: 'b', version: '1.0' }, 'c']);
+    expect(results.map(r => r.repoUrl)).toEqual([
+      '/orgs/X/sources/a/',
+      '/orgs/X/sources/b/',
+      '/orgs/X/sources/c/'
+    ]);
+  });
+
+  it('discards a batch whose result count does not match the request count', async () => {
+    // Never let result[0] be attributed to the wrong canonical.
+    const httpClient = {
+      post: jest.fn(async () => ({ data: [oclEntry({ url: '/orgs/A/sources/only/' })] }))
+    };
+    const logger = silentLogger();
+    const resolver = makeResolver({ httpClient, logger });
+
+    const results = await resolver.resolveReferences(['a', 'b']);
+
+    expect(results).toHaveLength(2);
+    expect(results.every(r => r.resolved === false)).toBe(true);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringMatching(/returned 1 result\(s\) for 2 reference\(s\).*misaligned/)
+    );
+  });
+});
+
+describe('OclReferenceResolver caching', () => {
+  it('serves a repeat reference from cache', async () => {
+    const httpClient = echoClient();
+    const resolver = makeResolver({ httpClient });
+
+    const first = await resolver.resolve('/orgs/A/sources/S/');
+    const second = await resolver.resolve('/orgs/A/sources/S/');
+
+    expect(httpClient.post).toHaveBeenCalledTimes(1);
+    expect(second).toEqual(first);
+  });
+
+  it('distinguishes references that differ only by a field', async () => {
+    const httpClient = echoClient();
+    const resolver = makeResolver({ httpClient });
+
+    await resolver.resolve({ url: 'S', code: '1' });
+    await resolver.resolve({ url: 'S', code: '2' });
+
+    expect(httpClient.post).toHaveBeenCalledTimes(2);
+  });
+
+  it('mixes cached and uncached references in one call, POSTing only the misses', async () => {
+    const httpClient = echoClient();
+    const resolver = makeResolver({ httpClient });
+
+    await resolver.resolve('a');
+    httpClient.post.mockClear();
+
+    const results = await resolver.resolveReferences(['a', 'b']);
+
+    expect(httpClient.post).toHaveBeenCalledTimes(1);
+    expect(httpClient.post.mock.calls[0][1]).toEqual(['b']);
+    expect(results.map(r => r.repoUrl)).toEqual(['/orgs/X/sources/a/', '/orgs/X/sources/b/']);
+  });
+
+  it('does not cache a failed resolution', async () => {
+    const httpClient = {
+      post: jest
+        .fn()
+        .mockRejectedValueOnce(httpError(400, { detail: 'bad' }))
+        .mockResolvedValueOnce({ data: [oclEntry({ url: '/orgs/A/sources/S/' })] })
+    };
+    const resolver = makeResolver({ httpClient, logger: silentLogger() });
+
+    const first = await resolver.resolve('/orgs/A/sources/S/');
+    const second = await resolver.resolve('/orgs/A/sources/S/');
+
+    expect(first.resolved).toBe(false);
+    expect(second.resolved).toBe(true);
+    expect(httpClient.post).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('OclReferenceResolver error handling', () => {
+  it('disables itself and falls back when the endpoint is missing (404)', async () => {
+    const httpClient = { post: jest.fn().mockRejectedValue(httpError(404)) };
+    const logger = silentLogger();
+    const resolver = makeResolver({ httpClient, logger });
+
+    await expect(resolver.resolveReferences(['a'])).resolves.toBeNull();
+    expect(resolver.isEnabled()).toBe(false);
+    expect(resolver.disabledReason).toBe('endpoint not implemented (404)');
+    expect(logger.info).toHaveBeenCalledWith(expect.stringMatching(/not available/));
+
+    // Stays disabled: no further requests.
+    await expect(resolver.resolveReferences(['b'])).resolves.toBeNull();
+    expect(httpClient.post).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([[401], [403]])('disables itself and falls back on %i', async status => {
+    const httpClient = { post: jest.fn().mockRejectedValue(httpError(status)) };
+    const logger = silentLogger();
+    const resolver = makeResolver({ httpClient, logger });
+
+    await expect(resolver.resolveReferences(['a'])).resolves.toBeNull();
+    expect(resolver.isEnabled()).toBe(false);
+    expect(resolver.disabledReason).toBe(`not authorised (${status})`);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/credentials/));
+  });
+
+  // A 400 is our bug, not the instance's — log it loudly but stay enabled, since a
+  // later well-formed batch may be fine.
+  it('reports a 400 without disabling', async () => {
+    const httpClient = { post: jest.fn().mockRejectedValue(httpError(400, { detail: 'malformed' })) };
+    const logger = silentLogger();
+    const resolver = makeResolver({ httpClient, logger });
+
+    const results = await resolver.resolveReferences(['a', 'b']);
+
+    expect(results).toHaveLength(2);
+    expect(results.every(r => r.resolved === false)).toBe(true);
+    expect(resolver.isEnabled()).toBe(true);
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('malformed'));
+  });
+
+  it('falls back on a network timeout without disabling', async () => {
+    const httpClient = { post: jest.fn().mockRejectedValue(new Error('timeout of 30000ms exceeded')) };
+    const logger = silentLogger();
+    const resolver = makeResolver({ httpClient, logger });
+
+    await expect(resolver.resolveReferences(['a'])).resolves.toBeNull();
+    expect(resolver.isEnabled()).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/timeout/));
+  });
+});

--- a/tests/ocl/ocl-vs-resolve-reference.test.js
+++ b/tests/ocl/ocl-vs-resolve-reference.test.js
@@ -89,6 +89,74 @@ describe('vs-ocl $resolveReference: collection resolution', () => {
     expect(get.mock.calls.some(c => /\/collections\/$/.test(c[0]))).toBe(true);
   });
 
+  it('resolves compose source canonicals in one batch, not one GET per source', async () => {
+    const CANON = 'http://x.org/vs/BatchVS';
+    const post = jest.fn(async (path, body) => ({
+      data: body.map(ref => {
+        if (typeof ref === 'string' && ref.startsWith('/orgs/MS/sources/')) {
+          const id = ref.split('/').filter(Boolean).pop();
+          return {
+            reference_type: 'relative', resolved: true,
+            result: { url: ref, owner_type: 'Organization', type: 'Source', canonical_url: `http://x.org/cs/${id}` }
+          };
+        }
+        return collectionResolve('/orgs/MS/collections/BC/', CANON);
+      })
+    }));
+    // NOTE: vs-ocl normalizes conceptsUrl/expansionUrl to ABSOLUTE urls without a
+    // trailing slash, so the mock matches by substring, not exact path.
+    const get = jest.fn(async (url, config) => {
+      if (url === '/orgs/MS/collections/BC/') {
+        return { data: { id: 'BC', url: '/orgs/MS/collections/BC/', canonical_url: CANON, version: 'HEAD', name: 'BC', owner: 'MS', owner_type: 'Organization' } };
+      }
+      if (url.includes('/expansions/')) {
+        return { data: {} }; // no resolved_source_versions -> fall through to source keys
+      }
+      if (url.includes('/collections/BC/concepts') && config?.params?.page !== undefined) {
+        const page = config.params.page || 1;
+        return { data: page === 1 ? [{ owner: 'MS', source: 'S1' }, { owner: 'MS', source: 'S2' }] : [] };
+      }
+      return { data: [] };
+    });
+    const { provider } = makeProvider({ post, get });
+
+    const vs = await provider.fetchValueSet(CANON, null);
+
+    expect(vs).toBeTruthy();
+    // POST #1 resolves the ValueSet canonical; POST #2 is ONE batch with both
+    // source paths — no per-source detail GETs.
+    expect(post).toHaveBeenCalledTimes(2);
+    expect(post.mock.calls[1][1]).toEqual(['/orgs/MS/sources/S1/', '/orgs/MS/sources/S2/']);
+    expect(get.mock.calls.some(c => /\/sources\/S[12]\/$/.test(c[0]))).toBe(false);
+    // The compose was built from the canonicals the batch returned.
+    const systems = (vs.jsonObj.compose?.include || []).map(i => i.system).sort();
+    expect(systems).toEqual(['http://x.org/cs/S1', 'http://x.org/cs/S2']);
+    // And the per-source cache was seeded for later callers.
+    expect(provider.sourceCanonicalCache.get('MS|S1')).toBe('http://x.org/cs/S1');
+  });
+
+  it('falls back to the search when the resolved collection version does not match', async () => {
+    const CANON = 'http://x.org/vs/VersionedVS';
+    const post = jest.fn(async () => ({ data: [collectionResolve('/orgs/MS/collections/VV/', CANON)] }));
+    const get = jest.fn(async (url) => {
+      if (url === '/orgs/MS/collections/VV/') {
+        // The repo is HEAD; the caller asked for v1.0 — mismatch.
+        return { data: { id: 'VV', url: '/orgs/MS/collections/VV/', canonical_url: CANON, version: 'HEAD', name: 'VV' } };
+      }
+      if (url === '/orgs/') return { data: [] };
+      return { data: [] };
+    });
+    const { provider } = makeProvider({ post, get });
+
+    const vs = await provider.fetchValueSet(CANON, '1.0');
+
+    // Resolver answered, the fetched collection was rejected on version, and the
+    // (empty) search ran — result is honestly null rather than the wrong version.
+    expect(post.mock.calls[0][1]).toEqual([{ url: CANON, version: '1.0' }]);
+    expect(get.mock.calls.some(c => c[0] === '/orgs/MS/collections/VV/')).toBe(true);
+    expect(vs).toBeNull();
+  });
+
   it('ignores a resolved repo that is not a collection', async () => {
     // OCL resolves the canonical to a *source*, not a collection: not a ValueSet.
     const post = jest.fn(async () => ({

--- a/tests/ocl/ocl-vs-resolve-reference.test.js
+++ b/tests/ocl/ocl-vs-resolve-reference.test.js
@@ -1,0 +1,109 @@
+// $resolveReference integration in the ValueSet provider: resolve a ValueSet
+// canonical to its collection without searching every org's collection listing.
+
+const { OCLValueSetProvider } = require('../../tx/ocl/vs-ocl');
+const { OclReferenceResolver } = require('../../tx/ocl/resolve/reference-resolver');
+
+function silentLogger() {
+  return { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+}
+
+// One $resolveReference entry resolving a canonical to a collection.
+function collectionResolve(repoUrl, canonical) {
+  return {
+    reference_type: 'canonical',
+    resolved: true,
+    resolution_url: repoUrl,
+    url_registry_entry: null,
+    result: {
+      url: repoUrl,
+      canonical_url: canonical,
+      owner_type: 'Organization',
+      type: 'Collection'
+    }
+  };
+}
+
+function makeProvider({ post, get } = {}) {
+  const provider = new OCLValueSetProvider({ org: 'MS', token: 'Token x' });
+  const httpClient = {
+    get: get || jest.fn(async () => ({ data: [] })),
+    post: post || jest.fn(async () => ({ data: [] }))
+  };
+  provider.httpClient = httpClient;
+  provider.referenceResolver = new OclReferenceResolver({
+    httpClient, token: 'Token x', logger: silentLogger()
+  });
+  return { provider, httpClient };
+}
+
+describe('vs-ocl $resolveReference: collection resolution', () => {
+  it('resolves an unenumerated collection via $resolveReference and skips the per-org search', async () => {
+    const collection = {
+      id: 'BRCID10', url: '/orgs/MS/collections/BRCID10/',
+      canonical_url: 'https://x/ValueSet/BRCID10', version: 'HEAD', name: 'BRCID10',
+      compose: { include: [] }
+    };
+    const post = jest.fn(async () => ({
+      data: [collectionResolve('/orgs/MS/collections/BRCID10/', 'https://x/ValueSet/BRCID10')]
+    }));
+    const get = jest.fn(async (url) => {
+      if (url === '/orgs/MS/collections/BRCID10/') return { data: collection };
+      return { data: [] };
+    });
+    const { provider, httpClient } = makeProvider({ post, get });
+
+    const vs = await provider.fetchValueSet('https://x/ValueSet/BRCID10', null);
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(vs).toBeTruthy();
+    expect(vs.url).toBe('https://x/ValueSet/BRCID10');
+    // The authoritative resolve means no /collections/ text search was issued.
+    const searched = httpClient.get.mock.calls.some(c => /\/collections\/$/.test(c[0]));
+    expect(searched).toBe(false);
+  });
+
+  it('falls back to the per-org search when the resolver is disabled (no token)', async () => {
+    const provider = new OCLValueSetProvider({ org: 'MS' }); // no token
+    const get = jest.fn(async (url) => {
+      if (/\/collections\/$/.test(url)) {
+        return {
+          data: [{
+            id: 'BRCID10', url: '/orgs/MS/collections/BRCID10/',
+            canonical_url: 'https://x/ValueSet/BRCID10', version: 'HEAD', name: 'BRCID10',
+            compose: { include: [] }
+          }]
+        };
+      }
+      if (url === '/orgs/') return { data: [{ id: 'MS' }] };
+      return { data: [] };
+    });
+    const post = jest.fn(async () => ({ data: [] }));
+    provider.httpClient = { get, post };
+
+    const vs = await provider.fetchValueSet('https://x/ValueSet/BRCID10', null);
+
+    expect(post).not.toHaveBeenCalled();
+    expect(vs).toBeTruthy();
+    // The text search path did run.
+    expect(get.mock.calls.some(c => /\/collections\/$/.test(c[0]))).toBe(true);
+  });
+
+  it('ignores a resolved repo that is not a collection', async () => {
+    // OCL resolves the canonical to a *source*, not a collection: not a ValueSet.
+    const post = jest.fn(async () => ({
+      data: [collectionResolve('/orgs/MS/sources/NotACollection/', 'https://x/ValueSet/BRCID10')]
+    }));
+    const get = jest.fn(async (url) => {
+      if (/\/collections\/$/.test(url)) return { data: [] }; // search finds nothing either
+      if (url === '/orgs/') return { data: [{ id: 'MS' }] };
+      return { data: [] };
+    });
+    const { provider } = makeProvider({ post, get });
+
+    const vs = await provider.fetchValueSet('https://x/ValueSet/BRCID10', null);
+
+    // Resolver answered a source, so we fell through to the search, which found nothing.
+    expect(vs).toBeNull();
+  });
+});

--- a/tx/ocl/README.md
+++ b/tx/ocl/README.md
@@ -39,14 +39,33 @@ In FHIRsmith terms, these providers are loaded by `tx/library.js` when a source 
 ## Runtime flow
 ### Metadata discovery
 CodeSystems (`cs-ocl.js`):
-- discover orgs via `/orgs/`
-- for each org, discover sources via `/orgs/{org}/sources/`
-- fallback to `/sources/` if org listing is unavailable
+- prefer one paginated crawl of the global `/sources/` listing (filtered to
+  organization-owned entries)
+- fallback: discover orgs via `/orgs/`, then `/orgs/{org}/sources/` per org
 
 ValueSets (`vs-ocl.js`):
-- discover orgs via `/orgs/`
-- discover collections via `/orgs/{org}/collections/`
-- fallback to `/collections/`
+- prefer one paginated crawl of the global `/collections/` listing (filtered to
+  organization-owned entries)
+- fallback: discover orgs via `/orgs/`, then `/orgs/{org}/collections/` per org
+
+### Visibility policy (org-only)
+An artifact is expected to live in an **organization** to be visible through the
+terminology service. User-owned repos (`/users/{user}/...`) are experimental by
+convention and are excluded from both discovery and `$resolveReference` results
+(a canonical resolving to a user-owned repo is treated as unresolved).
+
+### Canonical resolution via `$resolveReference`
+With a `token=` configured on the `ocl:` source line, the providers resolve
+"which repo holds this canonical URL?" through OCL's
+[`$resolveReference`](https://docs.openconceptlab.org/en/latest/oclapi/apireference/resolveReference.html)
+(global namespace) instead of iterating listings and matching `canonical_url`
+client-side. Used for ConceptMap source-system search, ValueSet lookup by
+canonical, and batched resolution of a collection's compose source canonicals.
+
+Without a token nothing changes: `$resolveReference` is authenticated on every
+instance probed (while the listing endpoints are public), so the resolver is
+constructed disabled and every caller keeps its previous search path. It also
+disables itself for the process on `404`/`401`/`403`.
 
 ConceptMaps (`cm-ocl.js`):
 - fetch by id via `/mappings/{id}/`

--- a/tx/ocl/README.md
+++ b/tx/ocl/README.md
@@ -67,6 +67,16 @@ instance probed (while the listing endpoints are public), so the resolver is
 constructed disabled and every caller keeps its previous search path. It also
 disables itself for the process on `404`/`401`/`403`.
 
+### CodeSystem default versions (release vs HEAD)
+OCL's own resolution treats a source's **latest release** as its default version
+(HEAD only when nothing is released), but discovery listings only ever report
+HEAD. With a token, discovery batch-resolves every canonical through
+`$resolveReference` and registers **both** versions: the release becomes what a
+versionless request gets (matching OCL), and HEAD stays reachable via an
+explicit `version=HEAD`. Only canonicals that are new or changed are re-resolved
+on refresh, so a steady-state cycle costs no extra requests. Without a token,
+discovery stays HEAD-only as before.
+
 ConceptMaps (`cm-ocl.js`):
 - fetch by id via `/mappings/{id}/`
 - search via `/mappings/` or `/orgs/{org}/mappings/`

--- a/tx/ocl/cm-ocl.cjs
+++ b/tx/ocl/cm-ocl.cjs
@@ -3,6 +3,7 @@ const { ConceptMap } = require('../library/conceptmap');
 const { PAGE_SIZE } = require('./shared/constants');
 const { createOclHttpClient } = require('./http/client');
 const { fetchAllPages, extractItemsAndNext } = require('./http/pagination');
+const { OclReferenceResolver, isOclRepoPath } = require('./resolve/reference-resolver');
 
 const DEFAULT_MAX_SEARCH_PAGES = 10;
 
@@ -22,6 +23,14 @@ class OCLConceptMapProvider extends AbstractConceptMapProvider {
     this._sourceCandidatesCache = new Map();
     this._sourceUrlsByCanonical = new Map();
     this._canonicalBySourceUrl = new Map();
+
+    // Asks OCL which repo holds a canonical instead of guessing via text search.
+    // Disabled unless a token is configured, in which case #candidateSourceUrls
+    // keeps using its existing search.
+    this.referenceResolver = new OclReferenceResolver({
+      httpClient: this.httpClient,
+      token: options.token || null
+    });
   }
 
   assignIds(ids) {
@@ -107,8 +116,12 @@ class OCLConceptMapProvider extends AbstractConceptMapProvider {
   async searchConceptMaps(searchParams, _elements) {
     this._validateSearchParams(searchParams);
 
+    // Keep the canonical exactly as supplied. Lower-casing it was harmless while
+    // every consumer compared through #norm() (which lower-cases anyway), but
+    // $resolveReference matches the canonical exactly, and OCL has no
+    // .../fhir/codesystem/x -- only .../fhir/CodeSystem/X.
     const params = Object.fromEntries(
-      searchParams.map(({ name, value }) => [name, String(value).toLowerCase()])
+      searchParams.map(({ name, value }) => [name, String(value)])
     );
     const sourceSystem = params['source-system'] || params.source || null;
     const targetSystem = params['target-system'] || params.target || null;
@@ -131,7 +144,7 @@ class OCLConceptMapProvider extends AbstractConceptMapProvider {
   async #collectMappingsForSearch(sourceSystem, targetSystem) {
     const systemUrl = sourceSystem || targetSystem;
     const candidates = await this.#candidateSourceUrls(systemUrl);
-    const sourcePaths = candidates.filter(s => String(s || '').startsWith('/orgs/'));
+    const sourcePaths = candidates.filter(isOclRepoPath);
 
     if (sourcePaths.length === 0) {
       return [];
@@ -283,7 +296,7 @@ class OCLConceptMapProvider extends AbstractConceptMapProvider {
     const targetCandidates = await this.#candidateSourceUrls(targetSystem);
 
     const mappings = [];
-    const sourcePaths = sourceCandidates.filter(s => String(s || '').startsWith('/orgs/'));
+    const sourcePaths = sourceCandidates.filter(isOclRepoPath);
 
     if (sourceCode && sourcePaths.length > 0) {
       for (const sourcePath of sourcePaths) {
@@ -515,14 +528,71 @@ class OCLConceptMapProvider extends AbstractConceptMapProvider {
       }
     }
 
-    const discovered = await this.#resolveSourceCandidatesFromOcl(systemUrl);
-    for (const item of discovered) {
-      result.add(item);
+    // Ask OCL which repo holds this canonical. An authoritative answer makes the
+    // heuristic text search below unnecessary; without one we fall back to it.
+    const resolved = await this.#resolveViaReferenceResolver(systemUrl);
+    if (resolved) {
+      result.add(resolved);
+    } else {
+      const discovered = await this.#resolveSourceCandidatesFromOcl(systemUrl);
+      for (const item of discovered) {
+        result.add(item);
+      }
     }
 
     const out = Array.from(result);
     this._sourceCandidatesCache.set(cacheKey, out);
     return out;
+  }
+
+  /**
+   * Resolve a canonical to its OCL repo via $resolveReference.
+   * Returns null when the resolver is disabled (no token), the endpoint is
+   * unavailable, or OCL cannot resolve the canonical -- in every case the caller
+   * falls back to the existing search.
+   */
+  async #resolveViaReferenceResolver(systemUrl) {
+    // Say why once, rather than per lookup: for a tokenless deployment this is the
+    // expected steady state, not an error.
+    if (!this.referenceResolver.isEnabled()) {
+      if (!this._resolverDisabledLogged) {
+        this._resolverDisabledLogged = true;
+        console.log(
+          `[OCL] $resolveReference not in use (${this.referenceResolver.disabledReason}); using source search`
+        );
+      }
+      return null;
+    }
+
+    let resolved;
+    try {
+      resolved = await this.referenceResolver.resolve(systemUrl);
+    } catch (error) {
+      console.warn(`[OCL] $resolveReference lookup failed for ${systemUrl}: ${error.message}`);
+      return null;
+    }
+
+    if (!resolved?.resolved || !resolved.repoUrl) {
+      console.log(`[OCL] $resolveReference did not resolve ${systemUrl}; falling back to source search`);
+      return null;
+    }
+
+    // Logged on success too: resolver and search return the same thing, so without
+    // this there is no way -- from outside or from the logs -- to tell which path ran.
+    console.log(`[OCL] $resolveReference resolved ${systemUrl} -> ${resolved.repoUrl}`);
+
+    // Keep the canonical<->repo caches coherent with the search path's bookkeeping.
+    // Index under what was asked, but record OCL's own canonical_url as the repo's
+    // canonical: echoing the request back would store whatever spelling the caller
+    // used rather than the repo's actual identity.
+    const canonicalKey = this.#norm(systemUrl);
+    if (!this._sourceUrlsByCanonical.has(canonicalKey)) {
+      this._sourceUrlsByCanonical.set(canonicalKey, new Set());
+    }
+    this._sourceUrlsByCanonical.get(canonicalKey).add(resolved.repoUrl);
+    this._canonicalBySourceUrl.set(this.#norm(resolved.repoUrl), resolved.canonical || systemUrl);
+
+    return resolved.repoUrl;
   }
 
   async #resolveSourceCandidatesFromOcl(systemUrl) {
@@ -572,7 +642,7 @@ class OCLConceptMapProvider extends AbstractConceptMapProvider {
       }
 
       const sourcePath = String(sourceUrl || '').trim();
-      if (!sourcePath.startsWith('/orgs/')) {
+      if (!isOclRepoPath(sourcePath)) {
         continue;
       }
 

--- a/tx/ocl/cm-ocl.cjs
+++ b/tx/ocl/cm-ocl.cjs
@@ -625,17 +625,52 @@ class OCLConceptMapProvider extends AbstractConceptMapProvider {
   }
 
   async #ensureCanonicalForSourceUrls(sourceUrls) {
+    // Deduplicate the repo paths that still need a canonical.
+    const pending = [];
+    const seen = new Set();
     for (const sourceUrl of sourceUrls || []) {
       const sourceKey = this.#norm(sourceUrl);
-      if (!sourceKey || this._canonicalBySourceUrl.has(sourceKey)) {
+      if (!sourceKey || this._canonicalBySourceUrl.has(sourceKey) || seen.has(sourceKey)) {
         continue;
       }
-
       const sourcePath = String(sourceUrl || '').trim();
       if (!isOclRepoPath(sourcePath)) {
         continue;
       }
+      seen.add(sourceKey);
+      pending.push(sourcePath);
+    }
 
+    if (pending.length === 0) {
+      return;
+    }
+
+    // One $resolveReference batch instead of one GET per source: the result
+    // carries the repo's canonical_url. Anything the batch cannot resolve falls
+    // through to the per-source GETs below, so behaviour without a token (or on
+    // failure) is unchanged.
+    if (this.referenceResolver.isEnabled()) {
+      try {
+        const results = await this.referenceResolver.resolveReferences(pending);
+        if (Array.isArray(results)) {
+          for (let i = 0; i < pending.length; i++) {
+            const r = results[i];
+            if (!r?.resolved || !r.canonical) {
+              continue;
+            }
+            const resolvedSourceUrl = r.repoUrl || pending[i];
+            this.#recordCanonicalForSource(pending[i], resolvedSourceUrl, r.canonical);
+          }
+        }
+      } catch (error) {
+        console.warn(`[OCL] $resolveReference batch for source canonicals failed: ${error.message}`);
+      }
+    }
+
+    for (const sourcePath of pending) {
+      if (this._canonicalBySourceUrl.has(this.#norm(sourcePath))) {
+        continue;
+      }
       try {
         const response = await this.httpClient.get(sourcePath);
         const source = response.data || {};
@@ -644,18 +679,24 @@ class OCLConceptMapProvider extends AbstractConceptMapProvider {
         if (!canonical) {
           continue;
         }
-
-        const canonicalKey = this.#norm(canonical);
-        if (!this._sourceUrlsByCanonical.has(canonicalKey)) {
-          this._sourceUrlsByCanonical.set(canonicalKey, new Set());
-        }
-        this._sourceUrlsByCanonical.get(canonicalKey).add(resolvedSourceUrl);
-        this._canonicalBySourceUrl.set(this.#norm(resolvedSourceUrl), canonical);
+        this.#recordCanonicalForSource(sourcePath, resolvedSourceUrl, canonical);
       } catch (e) {
         // Ignore source lookup failures and continue resolving remaining sources.
         continue;
       }
     }
+  }
+
+  #recordCanonicalForSource(requestedPath, resolvedSourceUrl, canonical) {
+    const canonicalKey = this.#norm(canonical);
+    if (!this._sourceUrlsByCanonical.has(canonicalKey)) {
+      this._sourceUrlsByCanonical.set(canonicalKey, new Set());
+    }
+    this._sourceUrlsByCanonical.get(canonicalKey).add(resolvedSourceUrl);
+    this._canonicalBySourceUrl.set(this.#norm(resolvedSourceUrl), canonical);
+    // Also index under the exact path we were asked about, so the "already
+    // resolved" checks hit even when OCL's repo url differs in shape.
+    this._canonicalBySourceUrl.set(this.#norm(requestedPath), canonical);
   }
 
   #queryTokenFromSystem(systemUrl) {

--- a/tx/ocl/cm-ocl.cjs
+++ b/tx/ocl/cm-ocl.cjs
@@ -4,6 +4,8 @@ const { PAGE_SIZE } = require('./shared/constants');
 const { createOclHttpClient } = require('./http/client');
 const { fetchAllPages, extractItemsAndNext } = require('./http/pagination');
 const { OclReferenceResolver, isOclRepoPath } = require('./resolve/reference-resolver');
+const Logger = require('../../library/logger');
+const oclCmLog = Logger.getInstance().child({ module: 'ocl-cm' });
 
 const DEFAULT_MAX_SEARCH_PAGES = 10;
 
@@ -547,8 +549,8 @@ class OCLConceptMapProvider extends AbstractConceptMapProvider {
     if (!this.referenceResolver.isEnabled()) {
       if (!this._resolverDisabledLogged) {
         this._resolverDisabledLogged = true;
-        console.log(
-          `[OCL] $resolveReference not in use (${this.referenceResolver.disabledReason}); using source search`
+        oclCmLog.info(
+          `$resolveReference not in use (${this.referenceResolver.disabledReason}); using source search`
         );
       }
       return null;
@@ -558,18 +560,18 @@ class OCLConceptMapProvider extends AbstractConceptMapProvider {
     try {
       resolved = await this.referenceResolver.resolve(systemUrl);
     } catch (error) {
-      console.warn(`[OCL] $resolveReference lookup failed for ${systemUrl}: ${error.message}`);
+      oclCmLog.warn(`$resolveReference lookup failed for ${systemUrl}: ${error.message}`);
       return null;
     }
 
     if (!resolved?.resolved || !resolved.repoUrl) {
-      console.log(`[OCL] $resolveReference did not resolve ${systemUrl}; falling back to source search`);
+      oclCmLog.info(`$resolveReference did not resolve ${systemUrl}; falling back to source search`);
       return null;
     }
 
     // Logged on success too: resolver and search return the same thing, so without
     // this there is no way -- from outside or from the logs -- to tell which path ran.
-    console.log(`[OCL] $resolveReference resolved ${systemUrl} -> ${resolved.repoUrl}`);
+    oclCmLog.info(`$resolveReference resolved ${systemUrl} -> ${resolved.repoUrl}`);
 
     // Keep the canonical<->repo caches coherent with the search path's bookkeeping.
     // Index under what was asked, but record OCL's own canonical_url as the repo's
@@ -663,7 +665,7 @@ class OCLConceptMapProvider extends AbstractConceptMapProvider {
           }
         }
       } catch (error) {
-        console.warn(`[OCL] $resolveReference batch for source canonicals failed: ${error.message}`);
+        oclCmLog.warn(`$resolveReference batch for source canonicals failed: ${error.message}`);
       }
     }
 

--- a/tx/ocl/cm-ocl.cjs
+++ b/tx/ocl/cm-ocl.cjs
@@ -153,29 +153,19 @@ class OCLConceptMapProvider extends AbstractConceptMapProvider {
     const allMappings = [];
     for (const sourcePath of sourcePaths) {
       const normalizedPath = this.#normalizeSourcePath(sourcePath);
-      let concepts;
       try {
-        concepts = await this.#fetchAllPages(
-          `${normalizedPath}concepts/`, { limit: PAGE_SIZE }, this.maxSearchPages
+        // Ask the source for its mappings directly. Walking concepts and asking
+        // each one costs a request per concept and, worse, only ever sees the
+        // first maxSearchPages of them -- for LOINC that is 1000 of 184683
+        // concepts (0.5%), so any mapping past that point was silently invisible.
+        // Verified live: both paths return the identical mapping set.
+        const mappings = await this.#fetchAllPages(
+          `${normalizedPath}mappings/`, { limit: PAGE_SIZE }, this.maxSearchPages
         );
+        allMappings.push(...mappings);
       } catch (_err) {
+        // source exposes no mappings endpoint or is inaccessible — skip
         continue;
-      }
-
-      for (const concept of concepts) {
-        const code = concept.id || concept.mnemonic;
-        if (!code) {
-          continue;
-        }
-        try {
-          const mappings = await this.#fetchAllPages(
-            `${normalizedPath}concepts/${encodeURIComponent(code)}/mappings/`,
-            { limit: PAGE_SIZE }, 2
-          );
-          allMappings.push(...mappings);
-        } catch (_err) {
-          // concept has no mappings or endpoint inaccessible — skip
-        }
       }
     }
 

--- a/tx/ocl/cs-ocl.cjs
+++ b/tx/ocl/cs-ocl.cjs
@@ -7,7 +7,7 @@ const { SearchFilterText } = require('../library/designations');
 const { PAGE_SIZE, CONCEPT_PAGE_SIZE, COLD_CACHE_FRESHNESS_MS, OCL_CODESYSTEM_MARKER_EXTENSION } = require('./shared/constants');
 const { createOclHttpClient } = require('./http/client');
 const { fetchAllPages, extractItemsAndNext } = require('./http/pagination');
-const { isOrgOwned } = require('./resolve/reference-resolver');
+const { OclReferenceResolver, isOrgOwned } = require('./resolve/reference-resolver');
 const { CACHE_CS_DIR, CACHE_VS_DIR, getCacheFilePath } = require('./cache/cache-paths');
 const { ensureCacheDirectories, getColdCacheAgeMs, formatCacheAgeMinutes } = require('./cache/cache-utils');
 const { computeCodeSystemFingerprint } = require('./fingerprint/fingerprint');
@@ -44,6 +44,16 @@ class OCLCodeSystemProvider extends AbstractCodeSystemProvider {
     this.baseUrl = http.baseUrl;
     this.httpClient = http.client;
 
+    // Resolves each source's DEFAULT version (latest release, else HEAD) so both
+    // get registered. Disabled without a token, in which case discovery stays
+    // HEAD-only exactly as before.
+    this.referenceResolver = new OclReferenceResolver({
+      httpClient: this.httpClient,
+      token: options.token || null
+    });
+    this._defaultVersionByCanonical = new Map();
+    this._headMetaByCanonical = new Map();
+
     this._codeSystemsByCanonical = new Map();
     this._idToCodeSystem = new Map();
     this.sourceMetaByUrl = new Map();
@@ -73,6 +83,7 @@ class OCLCodeSystemProvider extends AbstractCodeSystemProvider {
         oclLog.info(`Fetched ${sources.length} sources`);
 
         const snapshot = this.#buildSourceSnapshot(sources);
+        await this.#augmentSnapshotWithDefaultVersions(snapshot);
         this.#applySnapshot(snapshot);
 
         oclLog.info(`Loaded ${this._codeSystemsByCanonical.size} code systems`);
@@ -139,7 +150,94 @@ class OCLCodeSystemProvider extends AbstractCodeSystemProvider {
   }
 
   getSourceMetas() {
-    return Array.from(this.sourceMetaByUrl.values());
+    // Default metas first: registerProvider's unversioned key is first-wins, so
+    // the release (when one exists) becomes what a versionless request gets,
+    // matching OCL's own resolution. HEAD variants stay reachable via |HEAD.
+    return [
+      ...this.sourceMetaByUrl.values(),
+      ...this._headMetaByCanonical.values()
+    ];
+  }
+
+  /**
+   * Resolve each source's DEFAULT version via one chunked $resolveReference
+   * batch: OCL answers with the latest release, or HEAD when none is released.
+   * For sources whose default is a release, the snapshot entry becomes the
+   * release (CodeSystem resource, meta, versioned concepts URL) and the HEAD
+   * variant is kept as an extra meta, so BOTH versions get factories.
+   *
+   * Only canonicals that are new or whose listing checksum changed are
+   * re-resolved, so a steady-state refresh costs no extra requests. A no-op
+   * without a token: discovery stays HEAD-only exactly as before.
+   */
+  async #augmentSnapshotWithDefaultVersions(snapshot) {
+    if (!this.referenceResolver.isEnabled()) {
+      return;
+    }
+
+    const previousSnapshot = this._sourceStateByCanonical;
+    const toResolve = [];
+    for (const [canonicalUrl, entry] of snapshot.entries()) {
+      entry.baseChecksum = entry.checksum;
+      const previous = previousSnapshot.get(canonicalUrl);
+      const previousBase = previous?.baseChecksum ?? previous?.checksum ?? null;
+      if (!this._defaultVersionByCanonical.has(canonicalUrl) || previousBase !== entry.baseChecksum) {
+        toResolve.push(canonicalUrl);
+      }
+    }
+
+    if (toResolve.length > 0) {
+      const results = await this.referenceResolver.resolveReferences(toResolve, { bypassCache: true });
+      if (Array.isArray(results)) {
+        toResolve.forEach((canonicalUrl, i) => {
+          const r = results[i];
+          if (r?.resolved && r.result?.version) {
+            this._defaultVersionByCanonical.set(canonicalUrl, r.result.version);
+          } else {
+            this._defaultVersionByCanonical.delete(canonicalUrl);
+          }
+        });
+      } else {
+        // Resolver unavailable: keep whatever defaults we knew; new canonicals
+        // stay HEAD-only until a later cycle succeeds.
+        console.warn('[OCL] Default-version resolution unavailable; keeping previous defaults');
+      }
+    }
+
+    let releaseCount = 0;
+    for (const [canonicalUrl, entry] of snapshot.entries()) {
+      const defaultVersion = this._defaultVersionByCanonical.get(canonicalUrl);
+      const headVersion = entry.meta?.version || null;
+      if (!defaultVersion || defaultVersion === headVersion) {
+        continue;
+      }
+      const conceptsUrl = entry.meta?.conceptsUrl;
+      if (!conceptsUrl || !conceptsUrl.endsWith('concepts/')) {
+        continue;
+      }
+
+      const baseRepo = conceptsUrl.slice(0, -'concepts/'.length);
+      const releaseJson = structuredClone(entry.cs.jsonObj);
+      releaseJson.version = defaultVersion;
+      const releaseCs = new CodeSystem(releaseJson, 'R5', true);
+      const releaseMeta = {
+        ...entry.meta,
+        version: defaultVersion,
+        conceptsUrl: `${baseRepo}${encodeURIComponent(defaultVersion)}/concepts/`,
+        codeSystem: releaseCs
+      };
+
+      entry.headMeta = entry.meta;
+      entry.meta = releaseMeta;
+      entry.cs = releaseCs;
+      // A release being published or deleted must surface as "changed".
+      entry.checksum = `${entry.baseChecksum}|default=${defaultVersion}`;
+      releaseCount++;
+    }
+
+    if (releaseCount > 0) {
+      console.log(`[OCL] ${releaseCount} code system(s) defaulting to a released version (HEAD kept as |HEAD)`);
+    }
   }
 
   #scheduleRefresh() {
@@ -151,14 +249,24 @@ class OCLCodeSystemProvider extends AbstractCodeSystemProvider {
       try {
         const sources = await this.#fetchSourcesForDiscovery();
         const nextSnapshot = this.#buildSourceSnapshot(sources);
+        await this.#augmentSnapshotWithDefaultVersions(nextSnapshot);
         const changes = this.#diffSnapshots(this._sourceStateByCanonical, nextSnapshot);
         this.#applySnapshot(nextSnapshot);
-        for (const cs of changes.added || []) {
+        // Create factories for versions that appeared: the default (release) meta
+        // first so it claims the unversioned keys, then the HEAD variant. Covers
+        // both newly discovered sources and a release published on a known one.
+        for (const cs of [...(changes.added || []), ...(changes.changed || [])]) {
           const entry = nextSnapshot.get(cs.url);
-          if (entry?.meta && !OCLSourceCodeSystemFactory.hasFactory(cs.url, cs.version || null)) {
-            const factory = OCLSourceCodeSystemFactory.createForDiscoveredSource(this.httpClient, entry.meta);
+          for (const meta of [entry?.meta, entry?.headMeta]) {
+            if (!meta) {
+              continue;
+            }
+            if (OCLSourceCodeSystemFactory.hasExactFactory(meta.canonicalUrl, meta.version || null)) {
+              continue;
+            }
+            const factory = OCLSourceCodeSystemFactory.createForDiscoveredSource(this.httpClient, meta);
             if (factory) {
-              oclLog.info(`Factory created for newly discovered source: ${cs.url}`);
+              oclLog.info(`Factory created for ${meta.canonicalUrl}|${meta.version || ''}`);
             }
           }
         }
@@ -314,6 +422,7 @@ class OCLCodeSystemProvider extends AbstractCodeSystemProvider {
     this._codeSystemsByCanonical.clear();
     this._idToCodeSystem.clear();
     this.sourceMetaByUrl.clear();
+    this._headMetaByCanonical.clear();
     this._usedIds.clear();
 
     for (const [canonicalUrl, entry] of snapshot.entries()) {
@@ -338,6 +447,9 @@ class OCLCodeSystemProvider extends AbstractCodeSystemProvider {
       this._codeSystemsByCanonical.set(canonicalUrl, cs);
       this._idToCodeSystem.set(cs.id, cs);
       this.sourceMetaByUrl.set(canonicalUrl, meta);
+      if (entry.headMeta) {
+        this._headMetaByCanonical.set(canonicalUrl, entry.headMeta);
+      }
     }
 
     this._sourceStateByCanonical = snapshot;
@@ -1862,11 +1974,14 @@ class OCLSourceCodeSystemFactory extends CodeSystemFactoryProvider {
   }
 
   #resourceKey() {
-    const crypto = require('crypto');
+    // Plain `system|version`, matching how hasExactFactory/#findFactory build
+    // their lookup keys. This used to be a SHA-256 of the same string, which
+    // meant exact-version lookups could NEVER match a registered factory (plain
+    // string vs hash) — only the unversioned `system|` alias ever worked. The
+    // key is only used for in-memory maps, job keys and logs, so hashing bought
+    // nothing and broke version-aware matching.
     const normalizedSystem = OCLSourceCodeSystemFactory.#normalizeSystem(this.system());
-    const base = `${normalizedSystem}|${this.version() || ''}`;
-    const hash = crypto.createHash('sha256').update(base).digest('hex');
-    return hash;
+    return `${normalizedSystem}|${this.version() || ''}`;
   }
 
   currentChecksum() {

--- a/tx/ocl/cs-ocl.cjs
+++ b/tx/ocl/cs-ocl.cjs
@@ -7,6 +7,7 @@ const { SearchFilterText } = require('../library/designations');
 const { PAGE_SIZE, CONCEPT_PAGE_SIZE, COLD_CACHE_FRESHNESS_MS, OCL_CODESYSTEM_MARKER_EXTENSION } = require('./shared/constants');
 const { createOclHttpClient } = require('./http/client');
 const { fetchAllPages, extractItemsAndNext } = require('./http/pagination');
+const { isOrgOwned } = require('./resolve/reference-resolver');
 const { CACHE_CS_DIR, CACHE_VS_DIR, getCacheFilePath } = require('./cache/cache-paths');
 const { ensureCacheDirectories, getColdCacheAgeMs, formatCacheAgeMinutes } = require('./cache/cache-utils');
 const { computeCodeSystemFingerprint } = require('./fingerprint/fingerprint');
@@ -192,10 +193,36 @@ class OCLCodeSystemProvider extends AbstractCodeSystemProvider {
   }
 
   async #fetchSourcesForDiscovery() {
+    // Prefer the global listing: one paginated crawl instead of one listing per
+    // org (N+1 requests). Org-only policy: user-owned sources are experimental by
+    // convention and not visible to the terminology service, so filter them out.
+    try {
+      const all = await this.#fetchAllPages('/sources/');
+      if (Array.isArray(all) && all.length > 0) {
+        const seen = new Set();
+        const orgOwned = [];
+        for (const source of all) {
+          if (!source || typeof source !== 'object' || !isOrgOwned(source)) {
+            continue;
+          }
+          const key = this.#sourceIdentity(source);
+          if (seen.has(key)) {
+            continue;
+          }
+          seen.add(key);
+          orgOwned.push(source);
+        }
+        if (orgOwned.length > 0) {
+          return orgOwned;
+        }
+      }
+    } catch (error) {
+      console.warn(`[OCL] Global /sources/ listing failed (${error.message}); falling back to per-org discovery`);
+    }
+
     const organizations = await this.#fetchOrganizationIds();
     if (organizations.length === 0) {
-      // Fallback for OCL instances that expose global listing but not org listing.
-      return await this.#fetchAllPages('/sources/');
+      return [];
     }
 
     const allSources = [];

--- a/tx/ocl/cs-ocl.cjs
+++ b/tx/ocl/cs-ocl.cjs
@@ -200,7 +200,7 @@ class OCLCodeSystemProvider extends AbstractCodeSystemProvider {
       } else {
         // Resolver unavailable: keep whatever defaults we knew; new canonicals
         // stay HEAD-only until a later cycle succeeds.
-        console.warn('[OCL] Default-version resolution unavailable; keeping previous defaults');
+        oclLog.warn('Default-version resolution unavailable; keeping previous defaults');
       }
     }
 
@@ -236,7 +236,7 @@ class OCLCodeSystemProvider extends AbstractCodeSystemProvider {
     }
 
     if (releaseCount > 0) {
-      console.log(`[OCL] ${releaseCount} code system(s) defaulting to a released version (HEAD kept as |HEAD)`);
+      oclLog.info(`${releaseCount} code system(s) defaulting to a released version (HEAD kept as |HEAD)`);
     }
   }
 
@@ -325,7 +325,7 @@ class OCLCodeSystemProvider extends AbstractCodeSystemProvider {
         }
       }
     } catch (error) {
-      console.warn(`[OCL] Global /sources/ listing failed (${error.message}); falling back to per-org discovery`);
+      oclLog.warn(`Global /sources/ listing failed (${error.message}); falling back to per-org discovery`);
     }
 
     const organizations = await this.#fetchOrganizationIds();

--- a/tx/ocl/resolve/reference-resolver.js
+++ b/tx/ocl/resolve/reference-resolver.js
@@ -14,9 +14,10 @@
 
 const RESOLVE_PATH = '/$resolveReference/';
 
-// OCL repos are owned by an org OR a user. Matching only /orgs/ silently drops
-// every user-owned repo.
-const REPO_PATH_PATTERN = /^\/(orgs|users)\/[^/]+\//;
+// Org-only visibility policy: an artifact is expected to live in an organization
+// to be visible through the terminology service. User-owned repos (/users/...)
+// are experimental by convention and are excluded from discovery AND resolution.
+const REPO_PATH_PATTERN = /^\/orgs\/[^/]+\//;
 
 // Reference object fields forwarded to OCL. `namespace` is intentionally absent.
 const BODY_FIELDS = [
@@ -32,11 +33,27 @@ const BODY_FIELDS = [
 ];
 
 /**
- * True for a relative OCL repo path under either owner type, e.g.
- * `/orgs/CIEL/sources/CIEL/` or `/users/joe/sources/S/`.
+ * True for a relative OCL repo path the terminology service may serve — i.e. an
+ * organization-owned one (`/orgs/CIEL/sources/CIEL/`). User-owned paths
+ * (`/users/joe/...`) are rejected by policy.
  */
 function isOclRepoPath(value) {
   return REPO_PATH_PATTERN.test(String(value == null ? '' : value).trim());
+}
+
+/**
+ * Org-only policy check for an OCL repo payload or resolve result. Prefers the
+ * explicit owner_type when present; falls back to the path shape.
+ */
+function isOrgOwned(repo) {
+  if (!repo || typeof repo !== 'object') {
+    return false;
+  }
+  const ownerType = repo.owner_type || repo.ownerType || null;
+  if (ownerType) {
+    return ownerType === 'Organization';
+  }
+  return isOclRepoPath(repo.url);
 }
 
 /**
@@ -224,7 +241,16 @@ class OclReferenceResolver {
     }
 
     misses.forEach(({ body, index }, position) => {
-      const value = normalizeResult(payload[position], body);
+      let value = normalizeResult(payload[position], body);
+      // Org-only policy: a canonical resolving to a user-owned repo is treated as
+      // unresolved — user artifacts are experimental and not visible through the
+      // terminology service. Cached: the policy outcome is deterministic.
+      if (value.resolved && !isOrgOwned({ owner_type: value.ownerType, url: value.repoUrl })) {
+        this.#logger.info(
+          `[OCL] $resolveReference resolved ${cacheKey(body)} to a user-owned repo (${value.repoUrl}); org-only policy treats it as unresolved`
+        );
+        value = unresolved(body);
+      }
       this.#cache.set(cacheKey(body), value);
       output[index] = value;
     });
@@ -271,5 +297,6 @@ module.exports = {
   OclReferenceResolver,
   normalizeReference,
   isOclRepoPath,
+  isOrgOwned,
   RESOLVE_PATH
 };

--- a/tx/ocl/resolve/reference-resolver.js
+++ b/tx/ocl/resolve/reference-resolver.js
@@ -1,0 +1,275 @@
+// Client for OCL's $resolveReference operation.
+//
+// Answers "which OCL repo holds this canonical URL?" authoritatively, so callers
+// stop iterating source/collection listings to find a matching canonical_url. See
+// https://docs.openconceptlab.org/en/latest/oclapi/apireference/resolveReference.html
+//
+// Namespace is deliberately NOT supported: FHIR operations carry no namespace
+// parameter, so every resolution here runs in OCL's global namespace. Namespace
+// semantics (multi-tenant discrimination, sandboxing) are an open discussion with
+// the OCL team, not something to encode client-side yet.
+//
+// Plain .js rather than tx/ocl's .cjs+stub convention: jest's collectCoverageFrom
+// globs **/*.js only, so a .cjs module would be invisible to coverage.
+
+const RESOLVE_PATH = '/$resolveReference/';
+
+// OCL repos are owned by an org OR a user. Matching only /orgs/ silently drops
+// every user-owned repo.
+const REPO_PATH_PATTERN = /^\/(orgs|users)\/[^/]+\//;
+
+// Reference object fields forwarded to OCL. `namespace` is intentionally absent.
+const BODY_FIELDS = [
+  'url',
+  'version',
+  'code',
+  'display',
+  'id',
+  'filter',
+  'cascade',
+  'includeExclude',
+  'resourceType'
+];
+
+/**
+ * True for a relative OCL repo path under either owner type, e.g.
+ * `/orgs/CIEL/sources/CIEL/` or `/users/joe/sources/S/`.
+ */
+function isOclRepoPath(value) {
+  return REPO_PATH_PATTERN.test(String(value == null ? '' : value).trim());
+}
+
+/**
+ * Accepts either a relative/canonical URL string or an expanded reference object,
+ * returning the request-body form OCL expects.
+ */
+function normalizeReference(ref) {
+  if (typeof ref === 'string') {
+    const url = ref.trim();
+    if (!url) {
+      throw new Error('OCL reference string cannot be empty');
+    }
+    return url;
+  }
+
+  if (!ref || typeof ref !== 'object' || Array.isArray(ref)) {
+    throw new Error(`Invalid OCL reference: expected a string or object, got ${typeof ref}`);
+  }
+
+  const url = String(ref.url == null ? '' : ref.url).trim();
+  if (!url) {
+    throw new Error('OCL reference object requires a url');
+  }
+
+  const body = {};
+  for (const field of BODY_FIELDS) {
+    if (ref[field] !== undefined && ref[field] !== null) {
+      body[field] = ref[field];
+    }
+  }
+  return body;
+}
+
+function cacheKey(body) {
+  return typeof body === 'string' ? body : JSON.stringify(body);
+}
+
+function unresolved(request) {
+  return {
+    resolved: false,
+    repoUrl: null,
+    canonical: null,
+    ownerType: null,
+    resolutionUrl: null,
+    registryEntry: null,
+    referenceType: null,
+    request,
+    result: null
+  };
+}
+
+function normalizeResult(entry, request) {
+  if (!entry || typeof entry !== 'object') {
+    return unresolved(request);
+  }
+
+  const result = entry.result && typeof entry.result === 'object' ? entry.result : null;
+  const repoUrl = result && result.url ? result.url : null;
+
+  return {
+    resolved: Boolean(entry.resolved) && Boolean(repoUrl),
+    repoUrl,
+    // OCL returns the repo's own canonical_url and owner_type (richer than the
+    // documented example). Prefer them over echoing the request back: they are
+    // authoritative, the request is just whatever spelling the caller used.
+    canonical: result ? (result.canonical_url || result.canonicalUrl || null) : null,
+    ownerType: result ? (result.owner_type || result.ownerType || null) : null,
+    resolutionUrl: entry.resolution_url || null,
+    // Kept even though every observed response so far carries null: whether a URL
+    // Registry entry was involved is exactly what the OCL-team discussion needs.
+    registryEntry: entry.url_registry_entry || null,
+    referenceType: entry.reference_type || null,
+    request: entry.request === undefined ? request : entry.request,
+    result
+  };
+}
+
+class OclReferenceResolver {
+  #httpClient;
+  #logger;
+  #cache = new Map();
+  #enabled;
+  #disabledReason = null;
+
+  /**
+   * @param {object} options
+   * @param {object} options.httpClient - axios instance from createOclHttpClient
+   * @param {string} [options.token] - when absent the resolver stays disabled:
+   *   $resolveReference is authenticated on every OCL instance probed, while the
+   *   listing endpoints it replaces are public, so a tokenless call is a
+   *   guaranteed 401
+   * @param {object} [options.logger]
+   */
+  constructor({ httpClient, token = null, logger = console } = {}) {
+    if (!httpClient) {
+      throw new Error('OCL reference resolver requires an http client');
+    }
+
+    this.#httpClient = httpClient;
+    this.#logger = logger;
+    this.#enabled = Boolean(token);
+    if (!this.#enabled) {
+      this.#disabledReason = 'no token configured';
+    }
+  }
+
+  isEnabled() {
+    return this.#enabled;
+  }
+
+  get disabledReason() {
+    return this.#disabledReason;
+  }
+
+  #disable(reason) {
+    this.#enabled = false;
+    this.#disabledReason = reason;
+  }
+
+  /**
+   * Resolve one reference. Returns null when the resolver is unavailable, so the
+   * caller falls back to its existing path.
+   */
+  async resolve(ref) {
+    const results = await this.resolveReferences([ref]);
+    return results ? results[0] : null;
+  }
+
+  /**
+   * Resolve many references in one POST. Results come back in the caller's order.
+   *
+   * @returns {Promise<Array|null>} null when the resolver is unavailable (use fallback)
+   */
+  async resolveReferences(refs) {
+    if (!this.#enabled) {
+      return null;
+    }
+
+    const list = Array.isArray(refs) ? refs : [refs];
+    if (list.length === 0) {
+      return [];
+    }
+
+    const bodies = list.map(normalizeReference);
+    const output = new Array(bodies.length).fill(null);
+    const misses = [];
+
+    bodies.forEach((body, index) => {
+      const key = cacheKey(body);
+      if (this.#cache.has(key)) {
+        output[index] = this.#cache.get(key);
+      } else {
+        misses.push({ body, index });
+      }
+    });
+
+    if (misses.length === 0) {
+      return output;
+    }
+
+    let response;
+    try {
+      response = await this.#httpClient.post(RESOLVE_PATH, misses.map(m => m.body));
+    } catch (error) {
+      return this.#handleError(error, misses, output);
+    }
+
+    const payload = Array.isArray(response?.data)
+      ? response.data
+      : response?.data == null
+        ? []
+        : [response.data];
+
+    // Results are positional. On a count mismatch we cannot know which result
+    // belongs to which reference, so treat everything as unresolved rather than
+    // silently attributing a resolution to the wrong canonical.
+    if (payload.length !== misses.length) {
+      this.#logger.error(
+        `[OCL] $resolveReference returned ${payload.length} result(s) for ${misses.length} reference(s); discarding to avoid misaligned results`
+      );
+      for (const { body, index } of misses) {
+        output[index] = unresolved(body);
+      }
+      return output;
+    }
+
+    misses.forEach(({ body, index }, position) => {
+      const value = normalizeResult(payload[position], body);
+      this.#cache.set(cacheKey(body), value);
+      output[index] = value;
+    });
+
+    return output;
+  }
+
+  #handleError(error, misses, output) {
+    const status = error?.response?.status;
+
+    if (status === 404) {
+      this.#disable('endpoint not implemented (404)');
+      this.#logger.info(
+        `[OCL] $resolveReference is not available on this instance (404); using listing search instead`
+      );
+      return null;
+    }
+
+    if (status === 401 || status === 403) {
+      this.#disable(`not authorised (${status})`);
+      this.#logger.warn(
+        `[OCL] $resolveReference rejected our credentials (${status}); using listing search instead`
+      );
+      return null;
+    }
+
+    if (status === 400) {
+      // Our request body is wrong — a bug on this side. Don't disable: a later,
+      // well-formed batch may be fine.
+      const detail = error?.response?.data?.detail || error.message;
+      this.#logger.error(`[OCL] $resolveReference rejected the request body: ${detail}`);
+      for (const { body, index } of misses) {
+        output[index] = unresolved(body);
+      }
+      return output;
+    }
+
+    this.#logger.warn(`[OCL] $resolveReference failed: ${error.message}`);
+    return null;
+  }
+}
+
+module.exports = {
+  OclReferenceResolver,
+  normalizeReference,
+  isOclRepoPath,
+  RESOLVE_PATH
+};

--- a/tx/ocl/resolve/reference-resolver.js
+++ b/tx/ocl/resolve/reference-resolver.js
@@ -14,6 +14,10 @@
 
 const RESOLVE_PATH = '/$resolveReference/';
 
+// The live instance rejects large batches (403 somewhere between 150 and 200
+// references); 100 resolved in ~1.1s. Chunking is transparent to callers.
+const MAX_BATCH_SIZE = 100;
+
 // Org-only visibility policy: an artifact is expected to live in an organization
 // to be visible through the terminology service. User-owned repos (/users/...)
 // are experimental by convention and are excluded from discovery AND resolution.
@@ -183,11 +187,16 @@ class OclReferenceResolver {
   }
 
   /**
-   * Resolve many references in one POST. Results come back in the caller's order.
+   * Resolve many references, chunked into POSTs of at most MAX_BATCH_SIZE.
+   * Results come back in the caller's order.
    *
+   * @param {object} [options]
+   * @param {boolean} [options.bypassCache] - re-ask OCL even for cached entries
+   *   (the cache is still updated). Used by discovery refresh, where a source's
+   *   default version may have changed since it was last resolved.
    * @returns {Promise<Array|null>} null when the resolver is unavailable (use fallback)
    */
-  async resolveReferences(refs) {
+  async resolveReferences(refs, { bypassCache = false } = {}) {
     if (!this.#enabled) {
       return null;
     }
@@ -203,22 +212,32 @@ class OclReferenceResolver {
 
     bodies.forEach((body, index) => {
       const key = cacheKey(body);
-      if (this.#cache.has(key)) {
+      if (!bypassCache && this.#cache.has(key)) {
         output[index] = this.#cache.get(key);
       } else {
         misses.push({ body, index });
       }
     });
 
-    if (misses.length === 0) {
-      return output;
+    for (let start = 0; start < misses.length; start += MAX_BATCH_SIZE) {
+      const chunk = misses.slice(start, start + MAX_BATCH_SIZE);
+      const outcome = await this.#resolveChunk(chunk, output);
+      if (outcome === null) {
+        // Resolver became unavailable; the caller falls back wholesale rather
+        // than acting on a half-resolved set.
+        return null;
+      }
     }
 
+    return output;
+  }
+
+  async #resolveChunk(chunk, output) {
     let response;
     try {
-      response = await this.#httpClient.post(RESOLVE_PATH, misses.map(m => m.body));
+      response = await this.#httpClient.post(RESOLVE_PATH, chunk.map(m => m.body));
     } catch (error) {
-      return this.#handleError(error, misses, output);
+      return this.#handleError(error, chunk, output);
     }
 
     const payload = Array.isArray(response?.data)
@@ -228,19 +247,19 @@ class OclReferenceResolver {
         : [response.data];
 
     // Results are positional. On a count mismatch we cannot know which result
-    // belongs to which reference, so treat everything as unresolved rather than
+    // belongs to which reference, so treat the chunk as unresolved rather than
     // silently attributing a resolution to the wrong canonical.
-    if (payload.length !== misses.length) {
+    if (payload.length !== chunk.length) {
       this.#logger.error(
-        `[OCL] $resolveReference returned ${payload.length} result(s) for ${misses.length} reference(s); discarding to avoid misaligned results`
+        `[OCL] $resolveReference returned ${payload.length} result(s) for ${chunk.length} reference(s); discarding to avoid misaligned results`
       );
-      for (const { body, index } of misses) {
+      for (const { body, index } of chunk) {
         output[index] = unresolved(body);
       }
       return output;
     }
 
-    misses.forEach(({ body, index }, position) => {
+    chunk.forEach(({ body, index }, position) => {
       let value = normalizeResult(payload[position], body);
       // Org-only policy: a canonical resolving to a user-owned repo is treated as
       // unresolved — user artifacts are experimental and not visible through the

--- a/tx/ocl/vs-ocl.cjs
+++ b/tx/ocl/vs-ocl.cjs
@@ -1287,7 +1287,7 @@ class OCLValueSetProvider extends AbstractValueSetProvider {
         version ? { url: canonicalUrl, version } : canonicalUrl
       );
     } catch (error) {
-      console.warn(`[OCL-ValueSet] $resolveReference lookup failed for ${canonicalUrl}: ${error.message}`);
+      oclVsLog.warn(`$resolveReference lookup failed for ${canonicalUrl}: ${error.message}`);
       return null;
     }
 
@@ -1305,7 +1305,7 @@ class OCLValueSetProvider extends AbstractValueSetProvider {
       const response = await this.httpClient.get(resolved.repoUrl);
       collection = response?.data || null;
     } catch (error) {
-      console.warn(`[OCL-ValueSet] failed to fetch resolved collection ${resolved.repoUrl}: ${error.message}`);
+      oclVsLog.warn(`failed to fetch resolved collection ${resolved.repoUrl}: ${error.message}`);
       return null;
     }
 
@@ -1319,7 +1319,7 @@ class OCLValueSetProvider extends AbstractValueSetProvider {
       return null;
     }
 
-    console.log(`[OCL-ValueSet] $resolveReference resolved ${canonicalUrl} -> ${resolved.repoUrl}`);
+    oclVsLog.info(`$resolveReference resolved ${canonicalUrl} -> ${resolved.repoUrl}`);
     return collection;
   }
 
@@ -1407,7 +1407,7 @@ class OCLValueSetProvider extends AbstractValueSetProvider {
         }
       }
     } catch (error) {
-      console.warn(`[OCL-ValueSet] Global /collections/ listing failed (${error.message}); falling back to per-org discovery`);
+      oclVsLog.warn(`Global /collections/ listing failed (${error.message}); falling back to per-org discovery`);
     }
 
     const organizations = await this.#fetchOrganizationIds();
@@ -1915,7 +1915,7 @@ class OCLValueSetProvider extends AbstractValueSetProvider {
     try {
       results = await this.referenceResolver.resolveReferences(pending.map(p => p.ref));
     } catch (error) {
-      console.warn(`[OCL-ValueSet] $resolveReference batch failed: ${error.message}`);
+      oclVsLog.warn(`$resolveReference batch failed: ${error.message}`);
       return;
     }
 
@@ -1934,7 +1934,7 @@ class OCLValueSetProvider extends AbstractValueSetProvider {
       }
     }
     if (resolvedCount > 0) {
-      console.log(`[OCL-ValueSet] $resolveReference batch resolved ${resolvedCount}/${pending.length} source canonical(s) in one request`);
+      oclVsLog.info(`$resolveReference batch resolved ${resolvedCount}/${pending.length} source canonical(s) in one request`);
     }
   }
 

--- a/tx/ocl/vs-ocl.cjs
+++ b/tx/ocl/vs-ocl.cjs
@@ -9,6 +9,7 @@ const { TxParameters } = require('../params');
 const { OCLSourceCodeSystemFactory, OCLBackgroundJobQueue } = require('./cs-ocl');
 const { PAGE_SIZE, CONCEPT_PAGE_SIZE, FILTERED_CONCEPT_PAGE_SIZE, COLD_CACHE_FRESHNESS_MS } = require('./shared/constants');
 const { createOclHttpClient } = require('./http/client');
+const { OclReferenceResolver } = require('./resolve/reference-resolver');
 const { CACHE_VS_DIR, getCacheFilePath } = require('./cache/cache-paths');
 const { ensureCacheDirectories, getColdCacheAgeMs, formatCacheAgeMinutes } = require('./cache/cache-utils');
 const { computeValueSetExpansionFingerprint } = require('./fingerprint/fingerprint');
@@ -43,6 +44,13 @@ class OCLValueSetProvider extends AbstractValueSetProvider {
     const http = createOclHttpClient(options);
     this.baseUrl = http.baseUrl;
     this.httpClient = http.client;
+
+    // Resolves a canonical to its OCL repo authoritatively. Disabled without a
+    // token, in which case the search paths below run exactly as before.
+    this.referenceResolver = new OclReferenceResolver({
+      httpClient: this.httpClient,
+      token: options.token || null
+    });
 
     this.valueSetMap = new Map();
     this._idMap = new Map();
@@ -726,6 +734,11 @@ class OCLValueSetProvider extends AbstractValueSetProvider {
     }
 
     const sourceKeys = await this.#fetchCollectionSourceKeys(meta.conceptsUrl, meta.owner || null);
+    // Resolve every source's canonical in a single $resolveReference batch and seed
+    // the per-source cache, replacing one sequential GET per source. The loop below
+    // then reads from cache; anything the batch could not resolve falls through to
+    // the individual GET in #getSourceCanonicalUrl, so behaviour is unchanged.
+    await this.#primeSourceCanonicalsBatch(sourceKeys);
     for (const { owner, source } of sourceKeys) {
       const systemUrl = normalizeCanonicalSystem(await this.#getSourceCanonicalUrl(owner, source));
       if (systemUrl && !seen.has(systemUrl)) {
@@ -1185,6 +1198,15 @@ class OCLValueSetProvider extends AbstractValueSetProvider {
     }
 
     const pending = (async () => {
+      // Ask OCL which repo holds this canonical. An authoritative answer skips
+      // the per-org text search below; without one (no token, or the endpoint is
+      // unavailable) we fall through to it.
+      const resolvedCollection = await this.#resolveCollectionViaReference(canonicalUrl, version);
+      if (resolvedCollection) {
+        this.collectionByCanonicalCache.set(lookupKey, resolvedCollection);
+        return resolvedCollection;
+      }
+
       const organizations = await this.#fetchOrganizationIds();
       const endpoints = organizations.length > 0
         ? organizations.map(orgId => `/orgs/${encodeURIComponent(orgId)}/collections/`)
@@ -1249,6 +1271,56 @@ class OCLValueSetProvider extends AbstractValueSetProvider {
     } finally {
       this.pendingCollectionByCanonicalRequests.delete(lookupKey);
     }
+  }
+
+  /**
+   * Resolve a ValueSet canonical to its OCL collection via $resolveReference,
+   * then fetch the collection object so it matches the shape the text-search path
+   * returns. Returns null when the resolver is disabled (no token), the endpoint
+   * is unavailable, OCL cannot resolve it, or the resolved repo is not a
+   * collection -- in every case the caller falls back to the search.
+   */
+  async #resolveCollectionViaReference(canonicalUrl, version) {
+    let resolved;
+    try {
+      resolved = await this.referenceResolver.resolve(
+        version ? { url: canonicalUrl, version } : canonicalUrl
+      );
+    } catch (error) {
+      console.warn(`[OCL-ValueSet] $resolveReference lookup failed for ${canonicalUrl}: ${error.message}`);
+      return null;
+    }
+
+    if (!resolved?.resolved || !resolved.repoUrl) {
+      return null;
+    }
+
+    // $resolveReference resolves any repo type; only collections are ValueSets.
+    if (!/[/]collections[/]/.test(resolved.repoUrl)) {
+      return null;
+    }
+
+    let collection;
+    try {
+      const response = await this.httpClient.get(resolved.repoUrl);
+      collection = response?.data || null;
+    } catch (error) {
+      console.warn(`[OCL-ValueSet] failed to fetch resolved collection ${resolved.repoUrl}: ${error.message}`);
+      return null;
+    }
+
+    if (!collection || typeof collection !== 'object' || !collection.id) {
+      return null;
+    }
+
+    // Honour an explicit version: the resolved repo is HEAD unless OCL matched a
+    // version, so a mismatch means fall back to the version-aware search.
+    if (version && (collection.version || null) !== version) {
+      return null;
+    }
+
+    console.log(`[OCL-ValueSet] $resolveReference resolved ${canonicalUrl} -> ${resolved.repoUrl}`);
+    return collection;
   }
 
   #valueSetMetadataSignature(vs) {
@@ -1780,6 +1852,63 @@ class OCLValueSetProvider extends AbstractValueSetProvider {
       return await pending;
     } finally {
       this.pendingSourceCanonicalRequests.delete(key);
+    }
+  }
+
+  /**
+   * Resolve many sources' canonicals in one $resolveReference batch, seeding
+   * sourceCanonicalCache. A no-op when the resolver is disabled (no token) or the
+   * batch fails: #getSourceCanonicalUrl then falls back to its per-source GET, so
+   * this only ever saves round trips, never changes the result.
+   */
+  async #primeSourceCanonicalsBatch(sourceKeys) {
+    if (!this.referenceResolver.isEnabled()) {
+      return;
+    }
+
+    // Only sources not already cached, deduplicated by owner|source.
+    const pending = [];
+    const seen = new Set();
+    for (const { owner, source } of sourceKeys || []) {
+      if (!owner || !source) {
+        continue;
+      }
+      const key = `${owner}|${source}`;
+      if (this.sourceCanonicalCache.has(key) || seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      pending.push({ key, ref: `/orgs/${encodeURIComponent(owner)}/sources/${encodeURIComponent(source)}/` });
+    }
+
+    if (pending.length === 0) {
+      return;
+    }
+
+    let results;
+    try {
+      results = await this.referenceResolver.resolveReferences(pending.map(p => p.ref));
+    } catch (error) {
+      console.warn(`[OCL-ValueSet] $resolveReference batch failed: ${error.message}`);
+      return;
+    }
+
+    // null => resolver disabled or unavailable mid-flight; leave the cache untouched
+    // so the per-source GET fallback runs.
+    if (!Array.isArray(results)) {
+      return;
+    }
+
+    let resolvedCount = 0;
+    for (let i = 0; i < pending.length; i++) {
+      const canonical = results[i]?.resolved ? results[i].canonical : null;
+      if (canonical) {
+        this.sourceCanonicalCache.set(pending[i].key, canonical);
+        resolvedCount++;
+      }
+    }
+    if (resolvedCount > 0) {
+      console.log(`[OCL-ValueSet] $resolveReference batch resolved ${resolvedCount}/${pending.length} source canonical(s) in one request`);
     }
   }
 

--- a/tx/ocl/vs-ocl.cjs
+++ b/tx/ocl/vs-ocl.cjs
@@ -9,7 +9,7 @@ const { TxParameters } = require('../params');
 const { OCLSourceCodeSystemFactory, OCLBackgroundJobQueue } = require('./cs-ocl');
 const { PAGE_SIZE, CONCEPT_PAGE_SIZE, FILTERED_CONCEPT_PAGE_SIZE, COLD_CACHE_FRESHNESS_MS } = require('./shared/constants');
 const { createOclHttpClient } = require('./http/client');
-const { OclReferenceResolver } = require('./resolve/reference-resolver');
+const { OclReferenceResolver, isOrgOwned } = require('./resolve/reference-resolver');
 const { CACHE_VS_DIR, getCacheFilePath } = require('./cache/cache-paths');
 const { ensureCacheDirectories, getColdCacheAgeMs, formatCacheAgeMinutes } = require('./cache/cache-utils');
 const { computeValueSetExpansionFingerprint } = require('./fingerprint/fingerprint');
@@ -1383,10 +1383,36 @@ class OCLValueSetProvider extends AbstractValueSetProvider {
   }
 
   async #fetchCollectionsForDiscovery() {
+    // Prefer the global listing: one paginated crawl instead of one listing per
+    // org (N+1 requests). Org-only policy: user-owned collections are
+    // experimental by convention and not visible to the terminology service.
+    try {
+      const all = await this.#fetchAllPages('/collections/');
+      if (Array.isArray(all) && all.length > 0) {
+        const seen = new Set();
+        const orgOwned = [];
+        for (const collection of all) {
+          if (!collection || typeof collection !== 'object' || !isOrgOwned(collection)) {
+            continue;
+          }
+          const key = this.#collectionIdentity(collection);
+          if (seen.has(key)) {
+            continue;
+          }
+          seen.add(key);
+          orgOwned.push(collection);
+        }
+        if (orgOwned.length > 0) {
+          return orgOwned;
+        }
+      }
+    } catch (error) {
+      console.warn(`[OCL-ValueSet] Global /collections/ listing failed (${error.message}); falling back to per-org discovery`);
+    }
+
     const organizations = await this.#fetchOrganizationIds();
     if (organizations.length === 0) {
-      // Fallback for OCL instances that expose global listing but not org listing.
-      return await this.#fetchAllPages('/collections/');
+      return [];
     }
 
     const allCollections = [];


### PR DESCRIPTION
Adds `$resolveReference`-based canonical resolution to the OCL provider, so ConceptMap sources and ValueSet collections/compose sources are resolved by their global canonical URL rather than by guessing repo paths or walking concepts. Validated in production (tx.gointerop.com / Brazil DATASUS instance) since 2026-07-15 with no follow-up fixes. Scoped entirely to `tx/ocl/**` + `tests/ocl/**`.

This supersedes the earlier, incomplete #267.

## What's included
- **`$resolveReference` client** (`tx/ocl/resolve/reference-resolver.js`) — resolves a canonical URL to its OCL repo via the global namespace; chunked at 100 refs/request (the instance 403s past ~150); no-op with a clear disabled reason when no token is configured.
- **ConceptMap source resolution** — `cm-ocl.cjs` resolves source canonicals via `$resolveReference`, with a single batch call for the mixed set and a fallback to source search; fetches `{source}/mappings/` directly instead of walking every concept.
- **ValueSet collection/compose resolution** — `vs-ocl.cjs` resolves collections and compose sources the same way, batched.
- **Released-version-as-default** — a source's released version is served as the unversioned default; `|HEAD` remains addressable as an explicit variant (factories created for both `meta` and `headMeta`).
- **Org-only visibility policy** and **global-listing discovery** (`/sources/`, `/collections/`) with per-org fallback.
- **Logging** goes through the module logger (`Logger.getInstance().child({ module })`), consistent with #266.

## Requirements / notes
- Needs `token=` on the `ocl:` source line (kept in the deployment's `data/library.yml` volume; never committed). Without a token the resolver is disabled and the provider falls back to source search.
- Builds on #266 (post-startup factories + concept extras), now merged.

## Tests
5 new `tests/ocl/*` suites (resolver, CM/VS resolution, default-version, global discovery). Full OCL suite: **165 tests passing** on the current `main` base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
